### PR TITLE
プロフィールアイコンとヘッダーアイコンを共通化

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,8 @@
 @import "header";
 @import "devise";
 @import "form";
+@import "profile";
+@import "display";
 
 body {
   background-color: $bg-color;
@@ -25,4 +27,10 @@ body {
   font-size: 12px;
   background-color: #fff;
   padding: 8px 18px;
+}
+
+.icon {
+  border-radius: 50%;
+  width: 55px;
+  height: 55px;
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -24,12 +24,6 @@
   }
 }
 
-.header-icon {
-  border-radius: 50%;
-  width: 55px;
-  height: 55px;
-}
-
 .dropdown-content {
   // visibility: hidden;
   position: absolute;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,9 +23,10 @@
       - if user_signed_in?
         -# ログインしていれば実行（ログインアイコンを表示）
         .header-dropdown
-          = image_tag 'default-icon.png', class: 'header-icon drop-btn'
+          = image_tag 'default-icon.png', class: 'icon drop-btn'
           .dropdown-content
-            %a.dropdown-link{:href => "#"} プロフィール
+            -# プロフィール画面へのリンク
+            = link_to 'プロフィール', profile_path, class: 'dropdown-link'
             -# ログアウト機能の追加
             = link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: 'delete' }, class: 'dropdown-link'
       - else


### PR DESCRIPTION
【実装内容】
・プロフィールアイコンとヘッダーアイコンを共通コンポーネント化

【確認内容】
・プロフィール画面とヘッダーに共通化したアイコンが表示されること
・表示崩れがないこと