### PR TITLE
ログイン後にプロフィールが未完成であればプロフィール編集画面へリダイレクトする機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,11 +13,14 @@ class ApplicationController < ActionController::Base
     # ログインしていない場合、何もせず終了
     return unless user_signed_in?
 
-    # プロフィール画面の場合、何もせず終了
-    return if controller_name == "profiles"
+    # プロフィール編集・更新処理は対象外
+    return if controller_name == "profiles" && action_name.in?(%w[edit update])
+
+    # Devise認証関連の画面は対象外
+    return if devise_controller?
 
     # プロフィールの必須項目が入力されていなければ、プロフィール編集画面に遷移
-    unless current_user.profile.completed?
+    unless current_user.profile&.completed?
       redirect_to edit_profile_path
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,21 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  # ログイン後、プロフィールの必須項目が入力されていなければ、プロフィール編集画面に遷移
+  before_action :ensure_profile!
+
+  # ログイン後、プロフィールの必須項目が入力されていなければ、プロフィール編集画面に遷移
+  def ensure_profile!
+    # ログインしていない場合、何もせず終了
+    return unless user_signed_in?
+
+    # プロフィール画面の場合、何もせず終了
+    return if controller_name == "profiles"
+
+    # プロフィールの必須項目が入力されていなければ、プロフィール編集画面に遷移
+    unless current_user.profile.completed?
+      redirect_to edit_profile_path
+    end
+  end
 end


### PR DESCRIPTION
【実装内容】
・ApplicationControllerでログイン後のプロフィール未完成チェックを追加
・プロフィール未完成（必須項目未入力）の場合はプロフィール編集画面へリダイレクトする制御を実装
・プロフィール編集・更新画面はリダイレクト対象外とする
・Devise認証関連画面（ログイン・新規登録など）はリダイレクト対象外とする

【確認内容】
・ログイン後、プロフィール未完成（必須項目未入力）の場合にプロフィール編集画面へ遷移することを確認
・プロフィール編集・更新画面ではリダイレクトされないことを確認
・Devise認証関連画面ではリダイレクトされないことを確認

Closes #18