### PR TITLE
活動ジャンル（activity_genres）テーブルを作成

### DIFF
--- a/app/models/activity_genre.rb
+++ b/app/models/activity_genre.rb
@@ -1,0 +1,9 @@
+class ActivityGenre < ApplicationRecord
+  # プロフィールと活動ジャンルの多対多関係を中間テーブルで管理
+  has_many :profile_activity_genres
+  # 活動ジャンルに紐づくプロフィールを取得（中間テーブル経由）
+  has_many :profiles, through: :profile_activity_genres
+
+  # バリデーション設定
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20260418161112_create_activity_genres.rb
+++ b/db/migrate/20260418161112_create_activity_genres.rb
@@ -1,0 +1,9 @@
+class CreateActivityGenres < ActiveRecord::Migration[8.1]
+  def change
+    create_table :activity_genres do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_142030) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_161112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "activity_genres", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "profile_activity_genres", force: :cascade do |t|
+    t.bigint "activity_genre_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_genre_id"], name: "index_profile_activity_genres_on_activity_genre_id"
+    t.index ["profile_id"], name: "index_profile_activity_genres_on_profile_id"
+  end
 
   create_table "profiles", force: :cascade do |t|
     t.integer "activity_style"
@@ -45,5 +60,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_142030) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "profile_activity_genres", "activity_genres"
+  add_foreign_key "profile_activity_genres", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,33 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# 活動ジャンルを定義
+activity_genres = [
+  "J-ROCK",
+  "J-POP",
+  "ロック",
+  "ポップス",
+  "オルタナティブ",
+  "インディーズ",
+  "メタル",
+  "ハードロック",
+  "パンク",
+  "エモ",
+  "スクリーモ",
+  "ヒップホップ",
+  "R&B",
+  "ファンク",
+  "ジャズ",
+  "ブルース",
+  "クラシック",
+  "EDM",
+  "テクノ",
+  "アニソン",
+  "ボカロ"
+]
+
+activity_genres.each do |activity_genre|
+  # 同じ名前のデータがあればそれを使い、なければ新しく作る（重複防止）
+  ActivityGenre.find_or_create_by(name: activity_genre)
+end

--- a/test/fixtures/activity_genres.yml
+++ b/test/fixtures/activity_genres.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/activity_genre_test.rb
+++ b/test/models/activity_genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActivityGenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・ActivityGenreモデルを作成
・activity_genresテーブルを作成（migration）
・バリデーションを設定（nameの必須・一意性）
・seeds.rbに活動ジャンルを定義し、データを投入

【確認内容】
・Rails consoleでseedsのデータ反映を確認
・nameが未入力の場合に保存できないことを確認
・同じnameが重複登録できないことを確認

Closes #21