### PR TITLE
プロフィール_活動地域（profile_activity_areas）中間テーブルを作成

### DIFF
--- a/app/models/activity_area.rb
+++ b/app/models/activity_area.rb
@@ -1,4 +1,9 @@
 class ActivityArea < ApplicationRecord
+  # プロフィールと活動地域の多対多関係を中間テーブルで管理
+  has_many :profile_activity_areas, dependent: :restrict_with_error
+  # 活動地域に紐づくプロフィールを取得（中間テーブル経由）
+  has_many :profiles, through: :profile_activity_areas
+
   # バリデーション設定
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -5,6 +5,10 @@ class Profile < ApplicationRecord
   has_many :profile_activity_genres, dependent: :destroy
   # プロフィールに紐づく活動ジャンルを取得（中間テーブル経由）
   has_many :activity_genres, through: :profile_activity_genres
+  # プロフィールと活動地域の多対多関係を中間テーブルで管理
+  has_many :profile_activity_areas, dependent: :destroy
+  # プロフィールに紐づく活動地域を取得（中間テーブル経由）
+  has_many :activity_areas, through: :profile_activity_areas
 
   # 性別のパターンを定義
   enum :gender, { male: 0, female: 1, other: 2 }

--- a/app/models/profile_activity_area.rb
+++ b/app/models/profile_activity_area.rb
@@ -1,0 +1,7 @@
+class ProfileActivityArea < ApplicationRecord
+  belongs_to :profile
+  belongs_to :activity_area
+
+  # バリデーション設定（同じ活動地域の重複登録を防止）
+  validates :profile_id, uniqueness: { scope: :activity_area_id }
+end

--- a/db/migrate/20260425162105_create_profile_activity_areas.rb
+++ b/db/migrate/20260425162105_create_profile_activity_areas.rb
@@ -1,0 +1,10 @@
+class CreateProfileActivityAreas < ActiveRecord::Migration[8.1]
+  def change
+    create_table :profile_activity_areas do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.references :activity_area, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_154621) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_162105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_154621) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "profile_activity_areas", force: :cascade do |t|
+    t.bigint "activity_area_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_area_id"], name: "index_profile_activity_areas_on_activity_area_id"
+    t.index ["profile_id"], name: "index_profile_activity_areas_on_profile_id"
   end
 
   create_table "profile_activity_genres", force: :cascade do |t|
@@ -66,6 +75,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_154621) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "profile_activity_areas", "activity_areas"
+  add_foreign_key "profile_activity_areas", "profiles"
   add_foreign_key "profile_activity_genres", "activity_genres"
   add_foreign_key "profile_activity_genres", "profiles"
   add_foreign_key "profiles", "users"

--- a/test/fixtures/profile_activity_areas.yml
+++ b/test/fixtures/profile_activity_areas.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  profile: one
+  activity_area: one
+
+two:
+  profile: two
+  activity_area: two

--- a/test/models/profile_activity_area_test.rb
+++ b/test/models/profile_activity_area_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfileActivityAreaTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・ProfileActivityAreaモデルを作成
・profile_activity_areas中間テーブルを作成（migration）
・profilesテーブルとactivity_areasテーブルの多対多関連付けを設定
・同一活動地域の重複登録を防ぐバリデーションを追加

【確認内容】
・Rails consoleで紐付け確認

Closes #27