### PR TITLE
プロフィール_性格タグ（profile_personalities）中間テーブルを作成

### DIFF
--- a/app/models/personality.rb
+++ b/app/models/personality.rb
@@ -1,4 +1,9 @@
 class Personality < ApplicationRecord
+  # プロフィールと性格タグの多対多関係を中間テーブルで管理
+  has_many :profile_personalities, dependent: :restrict_with_error
+  # 性格タグに紐づくプロフィールを取得（中間テーブル経由）
+  has_many :profiles, through: :profile_personalities
+
   # バリデーション設定
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,6 +9,10 @@ class Profile < ApplicationRecord
   has_many :profile_activity_areas, dependent: :destroy
   # プロフィールに紐づく活動地域を取得（中間テーブル経由）
   has_many :activity_areas, through: :profile_activity_areas
+  # プロフィールと性格タグの多対多関係を中間テーブルで管理
+  has_many :profile_personalities, dependent: :destroy
+  # プロフィールに紐づく性格タグを取得（中間テーブル経由）
+  has_many :personalities, through: :profile_personalities
 
   # 性別のパターンを定義
   enum :gender, { male: 0, female: 1, other: 2 }

--- a/app/models/profile_personality.rb
+++ b/app/models/profile_personality.rb
@@ -1,0 +1,7 @@
+class ProfilePersonality < ApplicationRecord
+  belongs_to :profile
+  belongs_to :personality
+
+  # バリデーション設定（同じ性格タグの重複登録を防止）
+  validates :profile_id, uniqueness: { scope: :personality_id }
+end

--- a/db/migrate/20260425180844_create_profile_personalities.rb
+++ b/db/migrate/20260425180844_create_profile_personalities.rb
@@ -1,0 +1,10 @@
+class CreateProfilePersonalities < ActiveRecord::Migration[8.1]
+  def change
+    create_table :profile_personalities do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.references :personality, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_174531) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_180844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_174531) do
     t.index ["profile_id"], name: "index_profile_activity_genres_on_profile_id"
   end
 
+  create_table "profile_personalities", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "personality_id", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["personality_id"], name: "index_profile_personalities_on_personality_id"
+    t.index ["profile_id"], name: "index_profile_personalities_on_profile_id"
+  end
+
   create_table "profiles", force: :cascade do |t|
     t.integer "activity_style"
     t.text "bio"
@@ -85,5 +94,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_174531) do
   add_foreign_key "profile_activity_areas", "profiles"
   add_foreign_key "profile_activity_genres", "activity_genres"
   add_foreign_key "profile_activity_genres", "profiles"
+  add_foreign_key "profile_personalities", "personalities"
+  add_foreign_key "profile_personalities", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/profile_personalities.yml
+++ b/test/fixtures/profile_personalities.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  profile: one
+  personality: one
+
+two:
+  profile: two
+  personality: two

--- a/test/models/profile_personality_test.rb
+++ b/test/models/profile_personality_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfilePersonalityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・ProfilePersonalityモデルを作成
・profile_personalities中間テーブルを作成（migration）
・profilesテーブルとpersonalitiesテーブルの多対多関連付けを設定
・同一性格タグの重複登録を防ぐバリデーションを追加

【確認内容】
・Rails consoleで紐付け確認

Closes #31