### PR TITLE
好きなバンドタグ（favorite_bands）テーブルを作成

### DIFF
--- a/app/models/favorite_band.rb
+++ b/app/models/favorite_band.rb
@@ -1,0 +1,4 @@
+class FavoriteBand < ApplicationRecord
+  # バリデーション設定
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20260426011032_create_favorite_bands.rb
+++ b/db/migrate/20260426011032_create_favorite_bands.rb
@@ -1,0 +1,9 @@
+class CreateFavoriteBands < ActiveRecord::Migration[8.1]
+  def change
+    create_table :favorite_bands do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_180844) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_011032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_180844) do
   end
 
   create_table "activity_genres", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "favorite_bands", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -114,3 +114,62 @@ personalities.each do |personality|
   # 同じ名前のデータがあればそれを使い、なければ新しく作る（重複防止）
   Personality.find_or_create_by(name: personality)
 end
+
+# 好きなバンドタグを定義
+favorite_bands = [
+  "ONE OK ROCK",
+  "RADWIMPS",
+  "BUMP OF CHICKEN",
+  "Mr.Children",
+  "キングヌー",
+  "オフィシャルヒゲダンディズム",
+  "エメ",
+  "Perfume",
+  "嵐",
+  "乃木坂46",
+  "欅坂46",
+  "BABYMETAL",
+  "MAN WITH A MISSION",
+  "アレキサンドロス",
+  "LiSA",
+  "イヴ",
+  "YOASOBI",
+  "ジ・オーラル・シガレッツ",
+  "スキャンダル",
+  "あいみょん",
+  "サカナクション",
+  "King & Prince",
+  "スノーマン",
+  "スミカ",
+  "Coldrain",
+  "Fear, and Loathing in Las Vegas",
+  "凛として時雨",
+  "B’z",
+  "GLAY",
+  "LUNA SEA",
+  "ZARD",
+  "サザンオールスターズ",
+  "レディオヘッド",
+  "ミューズ",
+  "リンキンパーク",
+  "グリーンデイ",
+  "フーファイターズ",
+  "コールドプレイ",
+  "ニルヴァーナ",
+  "パラモア",
+  "イマジンドラゴンズ",
+  "レッドホットチリペッパーズ",
+  "クイーン",
+  "ビートルズ",
+  "バックストリートボーイズ",
+  "ワンディレクション",
+  "マルーン5",
+  "アデル",
+  "テイラースウィフト",
+  "エド・シーラン"
+]
+
+favorite_bands.each do |favorite_band|
+  # 同じ名前のデータがあればそれを使い、なければ新しく作る（重複防止）
+  FavoriteBand.find_or_create_by(name: favorite_band)
+end

--- a/test/fixtures/favorite_bands.yml
+++ b/test/fixtures/favorite_bands.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/favorite_band_test.rb
+++ b/test/models/favorite_band_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteBandTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・FavoriteBandモデルを作成
・favorite_bandsテーブルを作成（migration）
・バリデーションを設定（nameの必須・一意性）
・seeds.rbに好きなバンドタグを定義し、データを投入

【確認内容】
・Rails consoleでseedsのデータ反映を確認
・nameが未入力の場合に保存できないことを確認
・同じnameが重複登録できないことを確認

Closes #33