### PR TITLE
プロフィール_好きなバンドタグ（profile_favorite_bands）中間テーブルを作成

### DIFF
--- a/app/models/favorite_band.rb
+++ b/app/models/favorite_band.rb
@@ -1,4 +1,9 @@
 class FavoriteBand < ApplicationRecord
+  # プロフィールと好きなバンドタグの多対多関係を中間テーブルで管理
+  has_many :profile_favorite_bands, dependent: :restrict_with_error
+  # 好きなバンドタグに紐づくプロフィールを取得（中間テーブル経由）
+  has_many :profiles, through: :profile_favorite_bands
+
   # バリデーション設定
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,6 +13,10 @@ class Profile < ApplicationRecord
   has_many :profile_personalities, dependent: :destroy
   # プロフィールに紐づく性格タグを取得（中間テーブル経由）
   has_many :personalities, through: :profile_personalities
+  # プロフィールと好きなバンドタグの多対多関係を中間テーブルで管理
+  has_many :profile_favorite_bands, dependent: :destroy
+  # プロフィールに紐づく好きなバンドタグを取得（中間テーブル経由）
+  has_many :favorite_bands, through: :profile_favorite_bands
 
   # 性別のパターンを定義
   enum :gender, { male: 0, female: 1, other: 2 }

--- a/app/models/profile_favorite_band.rb
+++ b/app/models/profile_favorite_band.rb
@@ -1,0 +1,7 @@
+class ProfileFavoriteBand < ApplicationRecord
+  belongs_to :profile
+  belongs_to :favorite_band
+
+  # バリデーション設定（同じ好きなバンドタグの重複登録を防止）
+  validates :profile_id, uniqueness: { scope: :favorite_band_id }
+end

--- a/db/migrate/20260426013631_create_profile_favorite_bands.rb
+++ b/db/migrate/20260426013631_create_profile_favorite_bands.rb
@@ -1,0 +1,10 @@
+class CreateProfileFavoriteBands < ActiveRecord::Migration[8.1]
+  def change
+    create_table :profile_favorite_bands do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.references :favorite_band, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_011032) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_013631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,6 +54,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_011032) do
     t.datetime "updated_at", null: false
     t.index ["activity_genre_id"], name: "index_profile_activity_genres_on_activity_genre_id"
     t.index ["profile_id"], name: "index_profile_activity_genres_on_profile_id"
+  end
+
+  create_table "profile_favorite_bands", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "favorite_band_id", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["favorite_band_id"], name: "index_profile_favorite_bands_on_favorite_band_id"
+    t.index ["profile_id"], name: "index_profile_favorite_bands_on_profile_id"
   end
 
   create_table "profile_personalities", force: :cascade do |t|
@@ -100,6 +109,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_011032) do
   add_foreign_key "profile_activity_areas", "profiles"
   add_foreign_key "profile_activity_genres", "activity_genres"
   add_foreign_key "profile_activity_genres", "profiles"
+  add_foreign_key "profile_favorite_bands", "favorite_bands"
+  add_foreign_key "profile_favorite_bands", "profiles"
   add_foreign_key "profile_personalities", "personalities"
   add_foreign_key "profile_personalities", "profiles"
   add_foreign_key "profiles", "users"

--- a/test/fixtures/profile_favorite_bands.yml
+++ b/test/fixtures/profile_favorite_bands.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  profile: one
+  favorite_band: one
+
+two:
+  profile: two
+  favorite_band: two

--- a/test/models/profile_favorite_band_test.rb
+++ b/test/models/profile_favorite_band_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfileFavoriteBandTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・ProfileFavoriteBandモデルを作成
・profile_favorite_bands中間テーブルを作成（migration）
・profilesテーブルとfavorite_bandsテーブルの多対多関連付けを設定
・同一好きなバンドタグの重複登録を防ぐバリデーションを追加

【確認内容】
・Rails consoleで紐付け確認

Closes #35