### PR TITLE
プロフィールの活動ジャンル複数選択・保存・表示機能を実装

### DIFF
--- a/app/assets/stylesheets/display.scss
+++ b/app/assets/stylesheets/display.scss
@@ -12,6 +12,14 @@
 
 .display-group-title {
   font-size: 14px;
+  white-space: nowrap;
+}
+
+.display-tag-group {
+  display: flex;
+  justify-content: start;
+  align-items: start;
+  margin: 7px 0 0 0;
 }
 
 .display-group-content {
@@ -24,4 +32,22 @@
   & + & {
     margin-left: 5px;
   }
+}
+
+.display-tag-group-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: start;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+}
+
+.display-tag-group-content {
+  color: $main-color;
+  font-size: 12px;
+  border: 1px solid $main-color;
+  border-radius: 4px;
+  padding: 2px 5px;
+  list-style: none;
 }

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -75,15 +75,23 @@
   padding: 0 2px;
 }
 
+.check-boxes-container {
+  margin-top: 3px;
+}
+
+.check-box-group {
+  font-size: 14px;
+}
+
+checkbox {
+  border: none;
+  border: 1px solid $border-color;
+}
+
 .text-mini {
   font-size: 12px;
   text-decoration: none;
   color: $text-base-color;
-}
-
-.check-box {
-  border: none;
-  border: 1px solid $border-color;
 }
 
 .btn-container {

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -41,7 +41,6 @@ class ProfilesController < ApplicationController
       :part,
       :experience_year,
       :experience_month,
-      # :activity_genres,
       # :activity_areas,
       :activity_style,
       :practice_style,
@@ -51,6 +50,7 @@ class ProfilesController < ApplicationController
       # :favorite_bands,
       :sns_links,
       :bio,
+      activity_genre_ids: []
     )
   end
 end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -50,14 +50,17 @@
           %span.select-span ヶ月
       .form-group
         .label
-          = f.label :activity_genres, '活動ジャンル'
-        %div.select-container
-          = f.select :activity_genres, [['趣味', 'hobby'], ['アマチュア', 'amateur'], ['プロ', 'pro']], { include_blank: "" }, { class: 'select-field' }
-      .form-group
-        .label
           = f.label :activity_areas, '活動地域'
         %div.select-container
           = f.select :activity_areas, [['東京都', 'Tokyo'], ['愛知', 'Aichi'], ['大阪', 'Osaka']], { include_blank: "" }, { class: 'select-field' }
+      .form-group
+        .label
+          = f.label :activity_genres, '活動ジャンル'
+        %div.check-boxes-container
+          = f.collection_check_boxes :activity_genre_ids, ActivityGenre.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
       .form-group
         .label
           = f.label :activity_style, '活動志向'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -17,9 +17,11 @@
       .display-group
         .display-group-title 活動地域：
         .display-group-content= "東京都"
-      .display-group
+      .display-tag-group
         .display-group-title 活動ジャンル：
-        .display-group-content= "J-POP"
+        %ul.display-tag-group-wrapper
+          - @profile.activity_genres.each do |activity_genre|
+            %li.display-tag-group-content= activity_genre.name
       .display-group
         .display-group-title 活動志向：
         .display-group-content= @profile.activity_style


### PR DESCRIPTION
【実装内容】
・プロフィール編集画面に活動ジャンル一覧を表示
・チェックボックスで複数選択できるように実装
・選択した活動ジャンルを中間テーブルに保存できるように実装
・編集時に既存の選択状態を反映するように実装
・updateアクションでジャンルの更新処理を実施

【確認内容】
・編集時に既存の選択状態が反映されていることを確認
・保存後にプロフィール表示画面で選択した活動ジャンルが反映されていることを確認

Closes #37