### PR TITLE
プロフィールの活動地域の複数選択・保存・表示機能を実装

### DIFF
--- a/app/assets/stylesheets/display.scss
+++ b/app/assets/stylesheets/display.scss
@@ -1,13 +1,7 @@
 @import "variables";
 
 .display-group {
-  display: flex;
-  justify-content: start;
-  align-items: center;
-
-  & + & {
-    margin-top: 7px;
-  }
+  margin-top: 15px;
 }
 
 .display-group-title {
@@ -15,35 +9,16 @@
   white-space: nowrap;
 }
 
-.display-tag-group {
-  display: flex;
-  justify-content: start;
-  align-items: start;
-  margin: 7px 0 0 0;
-}
-
-.display-group-content {
-  color: $main-color;
-  font-size: 12px;
-  border: 1px solid $main-color;
-  border-radius: 4px;
-  padding: 2px 5px;
-
-  & + & {
-    margin-left: 5px;
-  }
-}
-
-.display-tag-group-wrapper {
+.display-group-wrapper {
   display: flex;
   flex-wrap: wrap;
   justify-content: start;
   gap: 5px;
-  margin: 0;
+  margin: 3px 0 0 0;
   padding: 0;
 }
 
-.display-tag-group-content {
+.display-group-content {
   color: $main-color;
   font-size: 12px;
   border: 1px solid $main-color;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -21,7 +21,6 @@
 .profile-title {
   border-bottom: 1px solid $border-color;
   margin-top: 40px;
-  margin-bottom: 7px;
 }
 
 .profile-text {

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -41,7 +41,6 @@ class ProfilesController < ApplicationController
       :part,
       :experience_year,
       :experience_month,
-      # :activity_areas,
       :activity_style,
       :practice_style,
       :music_type,
@@ -50,7 +49,8 @@ class ProfilesController < ApplicationController
       # :favorite_bands,
       :sns_links,
       :bio,
-      activity_genre_ids: []
+      activity_genre_ids: [],
+      activity_area_ids: []
     )
   end
 end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -51,8 +51,11 @@
       .form-group
         .label
           = f.label :activity_areas, '活動地域'
-        %div.select-container
-          = f.select :activity_areas, [['東京都', 'Tokyo'], ['愛知', 'Aichi'], ['大阪', 'Osaka']], { include_blank: "" }, { class: 'select-field' }
+        %div.check-boxes-container
+          = f.collection_check_boxes :activity_area_ids, ActivityArea.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
       .form-group
         .label
           = f.label :activity_genres, '活動ジャンル'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -11,17 +11,20 @@
     .profile-basic-info
       .profile-title 基本情報
       .display-group
-        .display-group-title 担当パート：
-        .display-group-content= @profile.part
-        .display-group-content= @profile.experience_text
+        .display-group-title 担当パート
+        .display-group-wrapper
+          .display-group-content= @profile.part
+          .display-group-content= @profile.experience_text
       .display-group
         .display-group-title 活動地域：
-        .display-group-content= "東京都"
-      .display-tag-group
+        %ul.display-group-wrapper
+          - @profile.activity_areas.each do |activity_area|
+            %li.display-group-content= activity_area.name
+      .display-group
         .display-group-title 活動ジャンル：
-        %ul.display-tag-group-wrapper
+        %ul.display-group-wrapper
           - @profile.activity_genres.each do |activity_genre|
-            %li.display-tag-group-content= activity_genre.name
+            %li.display-group-content= activity_genre.name
       .display-group
         .display-group-title 活動志向：
         .display-group-content= @profile.activity_style


### PR DESCRIPTION
【実装内容】
・プロフィール編集画面に活動地域一覧を表示
・チェックボックスで複数選択できるように実装
・選択した活動地域を中間テーブルに保存できるように実装
・編集時に既存の選択状態を反映するように実装
・updateアクションで活動地域の更新処理を実施

【確認内容】
・編集時に既存の選択状態が反映されていることを確認
・保存後にプロフィール表示画面で選択した活動地域が反映されていることを確認

Closes #39