### PR TITLE
プロフィールの性格タグの複数選択・保存・表示機能を実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -45,12 +45,12 @@ class ProfilesController < ApplicationController
       :practice_style,
       :music_type,
       :wants_live_performance,
-      # :personalities,
       # :favorite_bands,
       :sns_links,
       :bio,
       activity_genre_ids: [],
-      activity_area_ids: []
+      activity_area_ids: [],
+      personality_ids: []
     )
   end
 end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -87,8 +87,11 @@
       .form-group
         .label
           = f.label :personalities, '性格タグ'
-        %div.select-container
-          = f.select :personalities, [['フレンドリー', 'friendly'], ['明るい', 'cheerful'], ['聞き上手', 'listener']], { include_blank: "" }, { class: 'select-field' }
+        %div.check-boxes-container
+          = f.collection_check_boxes :personality_ids, Personality.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
       .form-group
         .label
           = f.label :favorite_bands, '好きなバンドタグ'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -43,8 +43,9 @@
       .profile-title マイタグ
       .display-group
         .display-group-title 性格タグ：
-        .display-group-content= "フレンドリー"
-        .display-group-content= "聞き上手"
+        %ul.display-group-wrapper
+          - @profile.personalities.each do |personality|
+            %li.display-group-content= personality.name
       .display-group
         .display-group-title 好きなバンドタグ：
         .display-group-content= "サザンオールスターズ"


### PR DESCRIPTION
【実装内容】
・プロフィール編集画面に性格タグ一覧を表示
・チェックボックスで複数選択できるように実装
・選択した性格タグを中間テーブルに保存できるように実装
・編集時に既存の選択状態を反映するように実装
・updateアクションで性格タグの更新処理を実施

【確認内容】
・編集時に既存の選択状態が反映されていることを確認
・保存後にプロフィール表示画面で選択した性格タグが反映されていることを確認

Closes #41