### PR TITLE
プロフィールの好きなバンドタグの複数選択・保存・表示機能を実装

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -15,7 +15,12 @@
 }
 
 .form-group {
-  margin-bottom: 20px;
+  margin: 0 0 20px 0;
+}
+
+.fieldset {
+  border: 1px solid $border-color;
+  margin: 0 0 20px 0;
 }
 
 .file {
@@ -84,7 +89,6 @@
 }
 
 checkbox {
-  border: none;
   border: 1px solid $border-color;
 }
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -45,12 +45,12 @@ class ProfilesController < ApplicationController
       :practice_style,
       :music_type,
       :wants_live_performance,
-      # :favorite_bands,
       :sns_links,
       :bio,
       activity_genre_ids: [],
       activity_area_ids: [],
-      personality_ids: []
+      personality_ids: [],
+      favorite_band_ids: []
     )
   end
 end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -48,17 +48,15 @@
           %span.select-span 年
           = f.select :experience_month, (0..11).to_a, { include_blank: "" },  class: 'select-field'
           %span.select-span ヶ月
-      .form-group
-        .label
-          = f.label :activity_areas, '活動地域'
+      %fieldset.fieldset
+        %legend 活動地域
         %div.check-boxes-container
           = f.collection_check_boxes :activity_area_ids, ActivityArea.all, :id, :name do |b|
             .check-box-group
               = b.check_box
               = b.label
-      .form-group
-        .label
-          = f.label :activity_genres, '活動ジャンル'
+      %fieldset.fieldset
+        %legend 活動ジャンル
         %div.check-boxes-container
           = f.collection_check_boxes :activity_genre_ids, ActivityGenre.all, :id, :name do |b|
             .check-box-group
@@ -84,19 +82,20 @@
           = f.label :wants_live_performance, 'ライブ出演希望'
         %div.select-container
           = f.select :wants_live_performance, [['有', true], ['無', false]] , { include_blank: "" }, { class: 'select-field' }
-      .form-group
-        .label
-          = f.label :personalities, '性格タグ'
+      %fieldset.fieldset
+        %legend 性格タグ
         %div.check-boxes-container
           = f.collection_check_boxes :personality_ids, Personality.all, :id, :name do |b|
             .check-box-group
               = b.check_box
               = b.label
-      .form-group
-        .label
-          = f.label :favorite_bands, '好きなバンドタグ'
-        %div.select-container
-          = f.select :favorite_bands, [['ONE OK ROCK', 'ONE OK ROCK'], ['RADWIMPS', 'RADWIMPS'], ['Perfume', 'Perfume']], { include_blank: "" }, { class: 'select-field' }
+      %fieldset.fieldset
+        %legend 好きなバンドタグ
+        %div.check-boxes-container
+          = f.collection_check_boxes :favorite_band_ids, FavoriteBand.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
       .form-group
         .label
           = f.label :sns_links, 'SNSリンク'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -48,8 +48,9 @@
             %li.display-group-content= personality.name
       .display-group
         .display-group-title 好きなバンドタグ：
-        .display-group-content= "サザンオールスターズ"
-        .display-group-content= "ONE OK ROCK"
+        %ul.display-group-wrapper
+          - @profile.favorite_bands.each do |favorite_band|
+            %li.display-group-content= favorite_band.name
     .profile-sns-links
       .profile-title SNSリンク
       .profile-text= @profile.sns_links


### PR DESCRIPTION
【実装内容】
・プロフィール編集画面に好きなバンドタグ一覧を表示
・プロフィール編集画面の複数選択肢のレイアウトを微修正（外枠をつける）
・チェックボックスで複数選択できるように実装
・選択した好きなバンドタグを中間テーブルに保存できるように実装
・編集時に既存の選択状態を反映するように実装
・updateアクションで好きなバンドタグの更新処理を実施

【確認内容】
・編集時に既存の選択状態が反映されていることを確認
・保存後にプロフィール表示画面で選択した好きなバンドタグが反映されていることを確認

Closes #43