### PR TITLE
プロフィール表示画面で未設定項目の表示制御を実装する

### DIFF
--- a/app/assets/stylesheets/display.scss
+++ b/app/assets/stylesheets/display.scss
@@ -25,4 +25,9 @@
   border-radius: 4px;
   padding: 2px 5px;
   list-style: none;
+  display: inline-block;
+}
+
+.unset {
+  display: none;
 }

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -11,7 +11,7 @@
 
 .form-container {
   background-color: #fff;
-  padding: 20px;
+  padding: 40px 20px;
 }
 
 .form-group {

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -20,7 +20,7 @@
 
 .profile-title {
   border-bottom: 1px solid $border-color;
-  margin-top: 40px;
+  margin-top: 80px;
 }
 
 .profile-text {

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,11 +72,11 @@ class Profile < ApplicationRecord
   end
 
   def experience_text
-    if experience_year == 0 && experience_month == 0
+    if experience_year == nil && experience_month == nil
       "未経験"
-    elseif experience_year == 0
+    elsif experience_year == nil
       "#{experience_month}ヶ月"
-    elseif experience_month == 0
+    elsif experience_month == nil
       "#{experience_year}年"
     else
       "#{experience_year}年#{experience_month}ヶ月"

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,11 +72,11 @@ class Profile < ApplicationRecord
   end
 
   def experience_text
-    if experience_year == nil && experience_month == nil
+    if experience_year.blank? && experience_month.blank?
       "未経験"
-    elsif experience_year == nil
+    elsif experience_year.blank?
       "#{experience_month}ヶ月"
-    elsif experience_month == nil
+    elsif experience_month.blank?
       "#{experience_year}年"
     else
       "#{experience_year}年#{experience_month}ヶ月"

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -44,9 +44,9 @@
         .label
           = f.label :experience_year, '担当歴'
         %div.select-container
-          = f.select :experience_year, (0..60).to_a, { include_blank: "" }, class: 'select-field'
+          = f.select :experience_year, (1..60).to_a, { include_blank: "" }, class: 'select-field'
           %span.select-span 年
-          = f.select :experience_month, (0..11).to_a, { include_blank: "" },  class: 'select-field'
+          = f.select :experience_month, (1..11).to_a, { include_blank: "" },  class: 'select-field'
           %span.select-span ヶ月
       %fieldset.fieldset
         %legend 活動地域

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -23,7 +23,7 @@
             - @profile.activity_areas.each do |activity_area|
               %li.display-group-content= activity_area.name
       .display-group
-        - if @profile.activity_areas.present?
+        - if @profile.activity_genres.present?
           .display-group-title 活動ジャンル
           %ul.display-group-wrapper
             - @profile.activity_genres.each do |activity_genre|

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -14,43 +14,52 @@
         .display-group-title 担当パート
         .display-group-wrapper
           .display-group-content= @profile.part
-          .display-group-content= @profile.experience_text
+          - if @profile.experience_text.present?
+            .display-group-content= @profile.experience_text
       .display-group
-        .display-group-title 活動地域：
-        %ul.display-group-wrapper
-          - @profile.activity_areas.each do |activity_area|
-            %li.display-group-content= activity_area.name
+        - if @profile.activity_areas.present?
+          .display-group-title 活動地域
+          %ul.display-group-wrapper
+            - @profile.activity_areas.each do |activity_area|
+              %li.display-group-content= activity_area.name
       .display-group
-        .display-group-title 活動ジャンル：
-        %ul.display-group-wrapper
-          - @profile.activity_genres.each do |activity_genre|
-            %li.display-group-content= activity_genre.name
+        - if @profile.activity_areas.present?
+          .display-group-title 活動ジャンル
+          %ul.display-group-wrapper
+            - @profile.activity_genres.each do |activity_genre|
+              %li.display-group-content= activity_genre.name
       .display-group
-        .display-group-title 活動志向：
-        .display-group-content= @profile.activity_style
+        - if @profile.activity_style.present?
+          .display-group-title 活動志向
+          .display-group-content= @profile.activity_style
     .profile-play-style
       .profile-title 活動スタイル
       .display-group
-        .display-group-title 練習スタイル：
-        .display-group-content= @profile.practice_style
+        - if @profile.practice_style.present?
+          .display-group-title 練習スタイル
+          .display-group-content= @profile.practice_style
       .display-group
-        .display-group-title 楽曲タイプ：
-        .display-group-content= @profile.music_type
+        - if @profile.music_type.present?
+          .display-group-title 楽曲タイプ
+          .display-group-content= @profile.music_type
       .display-group
-        .display-group-title ライブ出演希望：
-        .display-group-content= @profile.wants_live_performance
+        - if @profile.wants_live_performance.present?
+          .display-group-title ライブ出演希望
+          .display-group-content= @profile.wants_live_performance
     .profile-my-tag
       .profile-title マイタグ
       .display-group
-        .display-group-title 性格タグ：
-        %ul.display-group-wrapper
-          - @profile.personalities.each do |personality|
-            %li.display-group-content= personality.name
+        - if @profile.personalities.present?
+          .display-group-title 性格タグ
+          %ul.display-group-wrapper
+            - @profile.personalities.each do |personality|
+              %li.display-group-content= personality.name
       .display-group
-        .display-group-title 好きなバンドタグ：
-        %ul.display-group-wrapper
-          - @profile.favorite_bands.each do |favorite_band|
-            %li.display-group-content= favorite_band.name
+        - if @profile.favorite_bands.present?
+          .display-group-title 好きなバンドタグ
+          %ul.display-group-wrapper
+            - @profile.favorite_bands.each do |favorite_band|
+              %li.display-group-content= favorite_band.name
     .profile-sns-links
       .profile-title SNSリンク
       .profile-text= @profile.sns_links


### PR DESCRIPTION
【実装内容】
・プロフィール表示画面で任意入力項目の表示条件分岐を実装（present?）
 - 値がある場合はそのまま表示する
 - 未入力の場合は項目自体を非表示にする

【確認内容】
・各任意項目が未入力時に表示されないことを確認
・表示崩れがないことを確認

【追加対応】
・プロフィール表示画面の担当パートの経験年数を修正（未経験表示を追加）
・プロフィール編集画面の担当パートの経験年数を修正（選択肢から0の値を除外）

Closes #46
