### PR TITLE
募集_活動ジャンル（recruitment_activity_genres）中間テーブル作成

### DIFF
--- a/app/models/activity_genre.rb
+++ b/app/models/activity_genre.rb
@@ -3,6 +3,10 @@ class ActivityGenre < ApplicationRecord
   has_many :profile_activity_genres, dependent: :restrict_with_error
   # 活動ジャンルに紐づくプロフィールを取得（中間テーブル経由）
   has_many :profiles, through: :profile_activity_genres
+  # 募集と活動ジャンルの多対多関係を中間テーブルで管理
+  has_many :recruitment_activity_genres, dependent: :restrict_with_error
+  # 活動ジャンルに紐づく募集を取得（中間テーブル経由）
+  has_many :band_recruitments, through: :recruitment_activity_genres
 
   # バリデーション設定
   validates :name, presence: true, uniqueness: true

--- a/app/models/band_recruitment.rb
+++ b/app/models/band_recruitment.rb
@@ -1,6 +1,10 @@
 class BandRecruitment < ApplicationRecord
   # UserモデルとBandRecruitmentモデルを紐付け
   belongs_to :user
+  # 募集と活動ジャンルの多対多関係を中間テーブルで管理
+  has_many :recruitment_activity_genres, dependent: :destroy
+  # 募集に紐づく活動ジャンルを取得（中間テーブル経由）
+  has_many :activity_genres, through: :recruitment_activity_genres
 
   # 活動志向のパターンを定義
   enum :activity_style, { hobby: 0, amateur: 1, professional: 2 }

--- a/app/models/recruitment_activity_genre.rb
+++ b/app/models/recruitment_activity_genre.rb
@@ -1,0 +1,7 @@
+class RecruitmentActivityGenre < ApplicationRecord
+  belongs_to :band_recruitment
+  belongs_to :activity_genre
+
+  # バリデーション設定（同じ活動ジャンルの重複登録を防止）
+  validates :band_recruitment_id, uniqueness: { scope: :activity_genre_id }
+end

--- a/db/migrate/20260504050232_create_recruitment_activity_genres.rb
+++ b/db/migrate/20260504050232_create_recruitment_activity_genres.rb
@@ -1,0 +1,10 @@
+class CreateRecruitmentActivityGenres < ActiveRecord::Migration[8.1]
+  def change
+    create_table :recruitment_activity_genres do |t|
+      t.references :band_recruitment, null: false, foreign_key: true
+      t.references :activity_genre, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_170142) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_050232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -139,6 +139,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_170142) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "recruitment_activity_genres", force: :cascade do |t|
+    t.bigint "activity_genre_id", null: false
+    t.bigint "band_recruitment_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_genre_id"], name: "index_recruitment_activity_genres_on_activity_genre_id"
+    t.index ["band_recruitment_id"], name: "index_recruitment_activity_genres_on_band_recruitment_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -163,4 +172,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_170142) do
   add_foreign_key "profile_personalities", "personalities"
   add_foreign_key "profile_personalities", "profiles"
   add_foreign_key "profiles", "users"
+  add_foreign_key "recruitment_activity_genres", "activity_genres"
+  add_foreign_key "recruitment_activity_genres", "band_recruitments"
 end

--- a/test/fixtures/recruitment_activity_genres.yml
+++ b/test/fixtures/recruitment_activity_genres.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  recruitment: one
+  activity_genre: one
+
+two:
+  recruitment: two
+  activity_genre: two

--- a/test/models/recruitment_activity_genre_test.rb
+++ b/test/models/recruitment_activity_genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecruitmentActivityGenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・RecruitmentActivityGenreモデルを作成
・recruitment_activity_genres中間テーブルを作成（migration）
・band_recruitmentsテーブルとactivity_genresテーブルの多対多関連付けを設定
・同一活動ジャンルの重複登録を防ぐバリデーションを追加

【確認内容】
・Rails consoleで紐付け確認

Closes #58
