### PR TITLE
募集_パート（recruitment_parts）テーブル作成

### DIFF
--- a/app/models/band_recruitment.rb
+++ b/app/models/band_recruitment.rb
@@ -9,6 +9,8 @@ class BandRecruitment < ApplicationRecord
   has_many :recruitment_activity_areas, dependent: :destroy
   # 募集に紐づく活動地域を取得（中間テーブル経由）
   has_many :activity_areas, through: :recruitment_activity_areas
+  # 募集と募集パートの1対多関係を管理
+  has_many :recruitment_parts, dependent: :destroy
 
   # 活動志向のパターンを定義
   enum :activity_style, { hobby: 0, amateur: 1, professional: 2 }

--- a/app/models/recruitment_part.rb
+++ b/app/models/recruitment_part.rb
@@ -1,0 +1,12 @@
+class RecruitmentPart < ApplicationRecord
+  belongs_to :band_recruitment
+
+  # 募集パートのパターンを定義
+  enum :part, { vocal: 0, guitar: 1, bass: 2, drums: 3, keyboard: 4 }
+
+  # バリデーション設定
+  validates :part, presence: true
+  validates :max_count, presence: true
+  # 同じパートの重複登録を防止
+  validates :part, uniqueness: { scope: :band_recruitment_id }
+end

--- a/db/migrate/20260504153431_create_recruitment_parts.rb
+++ b/db/migrate/20260504153431_create_recruitment_parts.rb
@@ -1,0 +1,11 @@
+class CreateRecruitmentParts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :recruitment_parts do |t|
+      t.references :band_recruitment, null: false, foreign_key: true
+      t.integer :part, null: false
+      t.integer :max_count, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_070517) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_153431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -157,6 +157,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_070517) do
     t.index ["band_recruitment_id"], name: "index_recruitment_activity_genres_on_band_recruitment_id"
   end
 
+  create_table "recruitment_parts", force: :cascade do |t|
+    t.bigint "band_recruitment_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "max_count", null: false
+    t.integer "part", null: false
+    t.datetime "updated_at", null: false
+    t.index ["band_recruitment_id"], name: "index_recruitment_parts_on_band_recruitment_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -185,4 +194,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_070517) do
   add_foreign_key "recruitment_activity_areas", "band_recruitments"
   add_foreign_key "recruitment_activity_genres", "activity_genres"
   add_foreign_key "recruitment_activity_genres", "band_recruitments"
+  add_foreign_key "recruitment_parts", "band_recruitments"
 end

--- a/test/fixtures/recruitment_parts.yml
+++ b/test/fixtures/recruitment_parts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  band_recruitment: one
+  part: 1
+  max_count: 1
+
+two:
+  band_recruitment: two
+  part: 1
+  max_count: 1

--- a/test/models/recruitment_part_test.rb
+++ b/test/models/recruitment_part_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecruitmentPartTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・RecruitmentPartモデルを作成
・recruitment_partsテーブルを作成（migration）
・必要カラムを追加
・enumを定義（part）
・band_recruitmentsとrecruitment_partsの1:多関連付けを設定
・同一募集内でパートが重複しないようバリデーションを追加

【確認内容】
・Rails consoleで紐付け確認

Closes #64