### PR TITLE
募集編集機能を実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "display";
 @import "card";
 @import "band_recruitment";
+@import "flash";
 
 body {
   background-color: $bg-color;

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -14,7 +14,7 @@
   }
 
   &.detail {
-    padding: 0 15px 20px 0;
+    padding: 0 15px 30px 0;
   }
 }
 

--- a/app/assets/stylesheets/flash.scss
+++ b/app/assets/stylesheets/flash.scss
@@ -1,0 +1,54 @@
+.flash {
+  position: fixed;
+  top: 0;
+  right: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  width: 160px;
+  background: white;
+  // 古いSafari用
+  -webkit-animation: fade-in-out;
+  animation: fade-in-out;
+  visibility: hidden;
+  z-index: 100;
+  text-align: center;
+  animation-duration: 2s;
+}
+
+// アニメーションの動きを定義
+@-webkit-keyframes fade-in-out {
+  0% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  50% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in-out {
+  // 表示開始
+  0% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  // 表示途中
+  50% {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  // 表示終了
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -103,10 +103,7 @@
   display: flex;
   justify-content: start;
   align-items: center;
-
-  & + & {
-    margin-top: 5px;
-  }
+  margin-top: 5px;
 }
 
 .field-name {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -31,7 +31,7 @@
 }
 
 .dropdown-content {
-  visibility: hidden;
+  // visibility: hidden;
   position: absolute;
   top: 60px;
   left: -36px;

--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -62,7 +62,7 @@ class BandRecruitmentsController < ApplicationController
     @band_recruitment = BandRecruitment.find_by(id: params[:id])
     # 募集が存在しない場合はエラーを表示
     unless @band_recruitment.present?
-      return redirect_to band_recruitments_path, alert: "募集が見つかりません"
+      redirect_to band_recruitments_path, alert: "募集が見つかりません"
     end
   end
 
@@ -71,7 +71,7 @@ class BandRecruitmentsController < ApplicationController
 
     # 本人以外が編集できないように制御
     unless @band_recruitment.user_id == current_user.id
-      return redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
+      redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
     end
   end
 

--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -1,13 +1,13 @@
 # ApplicationControllerを継承
 class BandRecruitmentsController < ApplicationController
-  before_action :set_band_recruitment, only: [ :edit, :update ]
+  before_action :set_band_recruitment, only: [ :show ]
+  before_action :set_owned_band_recruitment, only: [ :edit, :update ]
 
   def index
     @band_recruitments = BandRecruitment.all
   end
 
   def show
-    @band_recruitment = BandRecruitment.find(params[:id])
   end
 
   def new
@@ -59,12 +59,19 @@ class BandRecruitmentsController < ApplicationController
   end
 
   def set_band_recruitment
-    @band_recruitment = BandRecruitment.find(params[:id])
+    @band_recruitment = BandRecruitment.find_by(id: params[:id])
+    # 募集が存在しない場合はエラーを表示
+    unless @band_recruitment.present?
+      return redirect_to band_recruitments_path, alert: "募集が見つかりません"
+    end
+  end
+
+  def set_owned_band_recruitment
+    @band_recruitment = BandRecruitment.find_by(id: params[:id])
 
     # 本人以外が編集できないように制御
     unless @band_recruitment.user_id == current_user.id
-      redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
-      return
+      return redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
     end
   end
 

--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -1,5 +1,7 @@
 # ApplicationControllerを継承
 class BandRecruitmentsController < ApplicationController
+  before_action :set_band_recruitment, only: [ :edit, :update ]
+
   def index
     @band_recruitments = BandRecruitment.all
   end
@@ -9,7 +11,7 @@ class BandRecruitmentsController < ApplicationController
   end
 
   def new
-    @band_recruitment = BandRecruitment.new
+    @band_recruitment = current_user.band_recruitments.new
 
     # 募集パートと必要人数の初期値を設定
     RecruitmentPart.parts.keys.each do |part|
@@ -24,11 +26,45 @@ class BandRecruitmentsController < ApplicationController
 
     # DBに値が保存されれば、作成された募集ページに飛ぶ
     if @band_recruitment.save
-      redirect_to band_recruitment_path(@band_recruitment)
+      redirect_to band_recruitment_path(@band_recruitment), notice: "作成できました"
     else
       rebuild_parts
+      flash.now[:error] = "作成できませんでした"
       # 同じリクエストのままnew.html.hamlを表示し直す
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    rebuild_parts
+  end
+
+  def update
+    # 空欄の募集パートは削除
+    params[:band_recruitment][:recruitment_parts_attributes]&.each_value do |attr|
+      if attr[:max_count].blank?
+        attr[:_destroy] = "1"
+      end
+    end
+
+    # 更新できたら、更新した募集詳細画面に飛ぶ
+    if @band_recruitment.update(band_recruitment_params)
+      redirect_to band_recruitment_path(@band_recruitment), notice: "更新できました"
+    else
+      rebuild_parts
+      flash.now[:error] = "更新できませんでした"
+      # 同じリクエストのままedit.html.hamlを表示し直す
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def set_band_recruitment
+    @band_recruitment = BandRecruitment.find(params[:id])
+
+    # 本人以外が編集できないように制御
+    unless @band_recruitment.user_id == current_user.id
+      redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
+      return
     end
   end
 

--- a/app/models/band_recruitment.rb
+++ b/app/models/band_recruitment.rb
@@ -13,7 +13,7 @@ class BandRecruitment < ApplicationRecord
   has_many :recruitment_parts, dependent: :destroy
   # 親モデル（募集テーブル）から子モデル（募集_パートテーブル）を一緒に保存できるように設定
   accepts_nested_attributes_for :recruitment_parts,
-    # 必要人数がblankまたは0の募集パートは保存しない
+    # 必要人数がblankの募集パートは保存しない
     reject_if: ->(attr) { attr["max_count"].blank? }, allow_destroy: true
 
   # 活動志向のパターンを定義
@@ -36,7 +36,7 @@ class BandRecruitment < ApplicationRecord
 
   # 募集パートは1つ以上入力必須
   def at_least_one_part_present
-    if recruitment_parts.all? { |part| part.max_count.blank? }
+    if recruitment_parts.all? { |rp| rp.max_count.blank? }
       errors.add(:base, "募集パートを1つ以上入力してください")
     end
   end

--- a/app/views/band_recruitments/edit.html.haml
+++ b/app/views/band_recruitments/edit.html.haml
@@ -1,0 +1,96 @@
+.container
+  -# エラーがある場合、メッセージを表示
+  -if @band_recruitment.errors.any?
+    %ul
+      - @band_recruitment.errors.full_messages.each do |message|
+        %li= message
+  .form-title 募集内容
+  .form-container
+    = form_with(model: @band_recruitment, url: band_recruitment_path(@band_recruitment), method: 'patch', local: true) do |f|
+      .form-group
+        .label
+          = f.label :team_name do
+            チーム名
+        %div
+          = f.text_field :team_name, class: 'text-field'
+      .form-group
+        .label
+          = f.label :title do
+            募集タイトル
+            %span.required *
+        %div
+          = f.text_field :title, class: 'text-field'
+      .form-group
+        .label
+          = f.label :part do
+            募集パート
+            %span.required *
+        %div
+          -# 募集パートをソート
+          - @band_recruitment.recruitment_parts.sort_by { |rp| RecruitmentPart.parts[rp.part] }.each do |rp|
+            = f.fields_for :recruitment_parts, rp  do |rp|
+              .form-field
+                .field-name
+                  -# 募集パート名の表示
+                  = I18n.t("enums.recruitment_part.part.#{rp.object.part}")
+                  -# paramsに値を入れる
+                  = rp.hidden_field :part
+                .field-content
+                  = rp.select :max_count, (1..5).to_a, { include_blank: "" },  class: 'select-field'
+                  %span.select-span 人
+      %fieldset.fieldset
+        %legend 活動地域
+        %div.check-boxes-container
+          = f.collection_check_boxes :activity_area_ids, ActivityArea.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
+      %fieldset.fieldset
+        %legend 活動ジャンル
+        %div.check-boxes-container
+          = f.collection_check_boxes :activity_genre_ids, ActivityGenre.all, :id, :name do |b|
+            .check-box-group
+              = b.check_box
+              = b.label
+      .form-group
+        .label
+          = f.label :activity_style, '活動志向'
+        %div.select-container
+          = f.select :activity_style, BandRecruitment.activity_styles.keys.map { |k| [I18n.t("enums.band_recruitment.activity_style.#{k}"), k]}, { include_blank: "" }, { class: 'select-field' }
+      .form-group
+        .label
+          = f.label :practice_frequency_unit, '練習頻度'
+        %div.select-container
+          = f.select :practice_frequency_unit, BandRecruitment.practice_frequency_units.keys.map { |k| [I18n.t("enums.band_recruitment.practice_frequency_unit.#{k}"), k]}, { include_blank: "" }, class: 'select-field'
+          %span.select-span に
+          = f.select :practice_frequency_count, (1..99).to_a, { include_blank: "" },  class: 'select-field'
+          %span.select-span 回
+      .form-group
+        .label
+          = f.label :practice_style, '練習スタイル'
+        %div.select-container
+          = f.select :practice_style, BandRecruitment.practice_styles.keys.map { |k| [I18n.t("enums.band_recruitment.practice_style.#{k}"), k]}, { include_blank: "" }, { class: 'select-field' }
+      .form-group
+        .label
+          = f.label :music_type, '楽曲タイプ'
+        %div.select-container
+          = f.select :music_type, BandRecruitment.music_types.keys.map { |k| [I18n.t("enums.band_recruitment.music_type.#{k}"), k]}, { include_blank: "" }, { class: 'select-field' }
+      .form-group
+        .label
+          = f.label :wants_live_performance, 'ライブ出演希望'
+        %div.select-container
+          = f.select :wants_live_performance, [['有', true], ['無', false]] , { include_blank: "" }, { class: 'select-field' }
+      .form-group
+        .label
+          = f.label :deadline do
+            期限
+            %span.required *
+        %div
+          = f.date_field :deadline, class: 'date-field'
+      .form-group
+        .label
+          = f.label :comment, '募集コメント'
+        %div
+          = f.text_area :comment, class: 'text-area'
+      .btn-container
+        = f.submit '保存', class: 'btn-secondary'

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -1,4 +1,9 @@
 .container
+  -# エラーがある場合、メッセージを表示
+  -if @band_recruitment.errors.any?
+    %ul
+      - @band_recruitment.errors.full_messages.each do |message|
+        %li= message
   .recruitment-card.detail
     .recruitment-card-top
       .card-status= @band_recruitment.status
@@ -62,9 +67,11 @@
             .display-group-title ライブ出演希望
             .display-group-wrapper
               .display-group-content= @band_recruitment.wants_live_performance
-      .recruitment-section
-        .display-title 募集コメント
-        .display-text= @band_recruitment.comment
+      - if @band_recruitment.comment.present?
+        .recruitment-section
+          .display-title 募集コメント
+          .display-text= @band_recruitment.comment
     -# プロフィール編集画面へのリンク
-    .display-edit-btn
-      = link_to "編集", edit_band_recruitment_path, class: "btn-secondary"
+    - if @band_recruitment.user_id == current_user.id
+      .display-edit-btn
+        = link_to "編集", edit_band_recruitment_path(@band_recruitment), class: "btn-secondary"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,9 +33,10 @@
       - else
         -# ログインしていない時
         = link_to 'ログイン', new_user_session_path, class: 'header-login-btn'
-    -# application.html.hamlに記述した内容はすべてのHTMLで表示され、yieldで個別のHTMLを読み込んでいる
+    -# flashの表示
     - if flash.present?
       .flash
         - flash.each do |key, value|
           %div{:class => key}= value
+    -# application.html.hamlに記述した内容はすべてのHTMLで表示され、yieldで個別のHTMLを読み込んでいる
     = yield


### PR DESCRIPTION
【実装内容】
・routes.rbにedit / updateルーティングを追加
・edit / updateアクションを作成
・edit.html.hamlを作成
・レイアウトを実装
・既存データをフォームに初期表示
・バリデーションエラーを表示
・更新成功時に詳細画面へリダイレクトするように実装
・本人以外が編集できないように制御（before_action）

【追加対応】
・flashの表示
・show画面で募集が存在しない場合はエラーを表示（before_action）

【確認内容】
・募集詳細画面の編集ボタンをクリックして、募集編集画面が表示されることを確認
・募集編集画面でフォームに既存データが初期表示されることを確認
・更新成功時に詳細画面へリダイレクトすることを確認
・更新失敗時にエラーメッセージが表示されることを確認
・本人以外が編集できないことを確認
・Rails consoleで動作確認

Closes #78