### PR TITLE
募集削除機能を実装

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,4 +1,5 @@
 $main-color: #f39306;
+$delete-color: #eb5625;
 $bg-color: #f0f0f0;
 $inactive-color: #a5a5a5;
 $border-color: #b6b6b6;

--- a/app/assets/stylesheets/button.scss
+++ b/app/assets/stylesheets/button.scss
@@ -23,6 +23,10 @@
   margin: 10px 0 8px 0;
   display: inline-block;
   cursor: pointer;
+
+  &.delete {
+    background-color: $delete-color;
+  }
 }
 
 .btn-add {

--- a/app/assets/stylesheets/display.scss
+++ b/app/assets/stylesheets/display.scss
@@ -56,7 +56,14 @@
   margin-top: 10px;
 }
 
+.display-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 30px;
+  margin: 50px 0 30px;
+}
+
 .display-edit-btn {
   text-align: center;
-  margin: 50px 0 30px;
 }

--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -1,7 +1,8 @@
 # ApplicationControllerを継承
 class BandRecruitmentsController < ApplicationController
+  before_action :authenticate_user!, only: [ :new, :create, :edit, :update, :destroy ]
   before_action :set_band_recruitment, only: [ :show ]
-  before_action :set_owned_band_recruitment, only: [ :edit, :update ]
+  before_action :set_owned_band_recruitment, only: [ :edit, :update, :destroy ]
 
   def index
     @band_recruitments = BandRecruitment.all
@@ -58,21 +59,19 @@ class BandRecruitmentsController < ApplicationController
     end
   end
 
+  def destroy
+    @band_recruitment.destroy!
+    # 削除できたら、募集一覧画面に飛ぶ
+    redirect_to root_path, status: :see_other, notice: "削除しました"
+  end
+
   def set_band_recruitment
-    @band_recruitment = BandRecruitment.find_by(id: params[:id])
-    # 募集が存在しない場合はエラーを表示
-    unless @band_recruitment.present?
-      redirect_to band_recruitments_path, alert: "募集が見つかりません"
-    end
+    @band_recruitment = BandRecruitment.find(params[:id])
   end
 
   def set_owned_band_recruitment
-    @band_recruitment = BandRecruitment.find_by(id: params[:id])
-
     # 本人以外が編集できないように制御
-    unless @band_recruitment.user_id == current_user.id
-      redirect_to band_recruitment_path(@band_recruitment), alert: "権限がありません"
-    end
+    @band_recruitment = current_user.band_recruitments.find(params[:id])
   end
 
   def rebuild_parts

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -73,5 +73,8 @@
           .display-text= @band_recruitment.comment
     -# プロフィール編集画面へのリンク
     - if @band_recruitment.user_id == current_user.id
-      .display-edit-btn
-        = link_to "編集", edit_band_recruitment_path(@band_recruitment), class: "btn-secondary"
+      .display-btn
+        .display-delete-btn
+          = link_to "削除", band_recruitment_path(@band_recruitment), data: { turbo_method: "delete", turbo_confirm: "本当に削除してもよろしいですか？"}, class: "btn-secondary delete"
+        .display-edit-btn
+          = link_to "編集", edit_band_recruitment_path(@band_recruitment), class: "btn-secondary"


### PR DESCRIPTION
【実装内容】
・routes.rbにdestroyルーティングを追加
・destroyアクションを作成
・詳細画面に削除ボタンを作成
・削除ボタンクリック時、確認ダイアログを表示
・本人以外が削除できないように制御
・削除成功時に一覧画面へリダイレクト

【確認内容】
・削除ボタンクリック時、確認ダイアログが表示されることを確認
・本人以外が削除できないことを確認
・削除成功時に一覧画面へリダイレクトすることを確認
・Rails consoleで動作確認

Closes #83