### PR TITLE
募集一覧・詳細画面のenum、booleanの日本語化と表示改善（I18n対応）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "propshaft"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", ">= 5.0"
+gem "puma", "~> 7.2", ">= 7.2.1"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -444,7 +444,7 @@ DEPENDENCIES
   kamal
   pg (~> 1.1)
   propshaft
-  puma (>= 5.0)
+  puma (~> 7.2, >= 7.2.1)
   rails (~> 8.1.2)
   rubocop-rails-omakase
   sassc-rails

--- a/app/assets/stylesheets/band_recruitment.scss
+++ b/app/assets/stylesheets/band_recruitment.scss
@@ -3,7 +3,7 @@
 .recruitment-container {
   display: grid;
   gap: 15px;
-  padding-top: 0;
+  padding: 15px 20px 100px;
 }
 
 .recruitment-section {

--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -5,7 +5,7 @@ class BandRecruitmentsController < ApplicationController
   before_action :set_owned_band_recruitment, only: [ :edit, :update, :destroy ]
 
   def index
-    @band_recruitments = BandRecruitment.all
+    @band_recruitments = BandRecruitment.order(updated_at: :desc)
   end
 
   def show

--- a/app/models/recruitment_part.rb
+++ b/app/models/recruitment_part.rb
@@ -1,5 +1,6 @@
 class RecruitmentPart < ApplicationRecord
-  belongs_to :band_recruitment
+  # 子が更新されたら親のupdated_atも更新する
+  belongs_to :band_recruitment, touch: true
 
   # 募集パートのパターンを定義
   enum :part, { vocal: 0, guitar: 1, bass: 2, drums: 3, keyboard: 4 }

--- a/app/views/band_recruitments/index.html.haml
+++ b/app/views/band_recruitments/index.html.haml
@@ -1,9 +1,9 @@
-.container.recruitment-container
+.recruitment-container
   - @band_recruitments.each do |band_recruitment|
     = link_to band_recruitment_path(band_recruitment), class: 'recruitment-card-link' do
       .recruitment-card
         .recruitment-card-top
-          .card-status= band_recruitment.status
+          .card-status= t("enums.band_recruitment.status.#{band_recruitment.status}")
           .card-deadline= "期限：#{band_recruitment.deadline}"
         .recruitment-card-middle
           .card-team
@@ -17,9 +17,9 @@
           .card-content
             .card-content-title 募集パート：
             %ul.card-content-list
-              - band_recruitment.recruitment_parts.each do |part|
-                %li.card-content-text= part.part
-                %span.card-content-count= "×#{part.max_count}"
+              - band_recruitment.recruitment_parts.sort_by { |rp| RecruitmentPart.parts[rp.part] }.each do |rp|
+                %li.card-content-text= t("enums.recruitment_part.part.#{rp.part}")
+                %span.card-content-count= "×#{rp.max_count}"
           .card-content
             .card-content-title 活動地域：
             - if band_recruitment.activity_areas.present?
@@ -40,13 +40,13 @@
             .card-content-title 活動志向：
             - if band_recruitment.activity_style.present?
               .card-content-list
-                .card-content-text= band_recruitment.activity_style
+                .card-content-text= t("enums.band_recruitment.activity_style.#{band_recruitment.activity_style}")
             - else
               .card-content-text 未設定
           .card-icon-container
             = image_tag band_recruitment.user.profile.avatar_image, class: 'card-icon'
             .card-icon-info
-              .card-icon-info-top= "#{band_recruitment.user.profile.nickname} (#{band_recruitment.user.profile.part})"
-              .card-icon-info-bottom= "#{band_recruitment.user.profile.calculate_age}歳 / #{band_recruitment.user.profile.gender}"
+              .card-icon-info-top= "#{band_recruitment.user.profile.nickname} (#{t("ui.parts.short.#{band_recruitment.user.profile.part}")})"
+              .card-icon-info-bottom= "#{band_recruitment.user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{band_recruitment.user.profile.gender}")}"
 .display-create-btn
   = link_to "", new_band_recruitment_path, class: "btn-add"

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -6,7 +6,7 @@
         %li= message
   .recruitment-card.detail
     .recruitment-card-top
-      .card-status= @band_recruitment.status
+      .card-status= t("enums.band_recruitment.status.#{@band_recruitment.status}")
       .card-deadline= "期限：#{@band_recruitment.deadline}"
     .recruitment-card-middle
       .card-team
@@ -19,17 +19,17 @@
       .card-icon-container.detail
         = image_tag @band_recruitment.user.profile.avatar_image, class: 'card-icon'
         .card-icon-info
-          .card-icon-info-top= "#{@band_recruitment.user.profile.nickname} (#{@band_recruitment.user.profile.part})"
-          .card-icon-info-bottom= "#{@band_recruitment.user.profile.calculate_age}歳 / #{@band_recruitment.user.profile.gender}"
+          .card-icon-info-top= "#{@band_recruitment.user.profile.nickname} (#{t("ui.parts.short.#{@band_recruitment.user.profile.part}")})"
+          .card-icon-info-bottom= "#{@band_recruitment.user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{@band_recruitment.user.profile.gender}")}"
     .recruitment-card-bottom
       .recruitment-section
         .display-title 募集条件
         .display-group-recruitment
           .display-group-title 募集パート
           .display-group-wrapper
-            - @band_recruitment.recruitment_parts.each do |part|
-              .display-group-content= part.part
-              %span.card-content-count-lg= "×#{part.max_count}"
+            - @band_recruitment.recruitment_parts.sort_by { |rp| RecruitmentPart.parts[rp.part] }.each do |rp|
+              .display-group-content= t("enums.recruitment_part.part.#{rp.part}")
+              %span.card-content-count-lg= "×#{rp.max_count}"
         - if @band_recruitment.activity_areas.present?
           .display-group-recruitment
             .display-group-title 活動地域
@@ -46,31 +46,31 @@
           .display-group-recruitment
             .display-group-title 活動志向
             .display-group-wrapper
-              .display-group-content= @band_recruitment.activity_style
+              .display-group-content= t("enums.band_recruitment.activity_style.#{@band_recruitment.activity_style}")
         - if @band_recruitment.music_type.present?
           .display-group-recruitment
             .display-group-title 楽曲タイプ
             .display-group-wrapper
-              .display-group-content= @band_recruitment.music_type
-        - if @band_recruitment.practice_frequency_unit.present? || @band_recruitment.practice_frequency_count.present?
+              .display-group-content= t("enums.band_recruitment.music_type.#{@band_recruitment.music_type}")
+        - if @band_recruitment.practice_frequency_unit.present? && @band_recruitment.practice_frequency_count.present?
           .display-group-recruitment
             .display-group-title 練習頻度
             .display-group-wrapper
-              .display-group-content= "#{@band_recruitment.practice_frequency_unit}に#{@band_recruitment.practice_frequency_count}回"
+              .display-group-content= "#{t("enums.band_recruitment.practice_frequency_unit.#{@band_recruitment.practice_frequency_unit}")}に#{@band_recruitment.practice_frequency_count}回"
         - if @band_recruitment.practice_style.present?
           .display-group-recruitment
             .display-group-title 練習スタイル
             .display-group-wrapper
-              .display-group-content= @band_recruitment.practice_style
+              .display-group-content= t("enums.band_recruitment.practice_style.#{@band_recruitment.practice_style}")
         - unless @band_recruitment.wants_live_performance.nil?
           .display-group-recruitment
             .display-group-title ライブ出演希望
             .display-group-wrapper
-              .display-group-content= @band_recruitment.wants_live_performance
+              .display-group-content= t("ui.boolean.#{@band_recruitment.wants_live_performance}")
       - if @band_recruitment.comment.present?
         .recruitment-section
           .display-title 募集コメント
-          .display-text= @band_recruitment.comment
+          .display-text= simple_format(@band_recruitment.comment)
     -# プロフィール編集画面へのリンク
     - if @band_recruitment.user_id == current_user.id
       .display-btn

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -100,11 +100,11 @@
         .label
           = f.label :sns_links, 'SNSリンク'
         %div
-          = f.text_field :sns_links, class: 'text-field'
+          = f.text_area :sns_links, class: 'text-area'
       .form-group
         .label
           = f.label :bio, '自己紹介'
         %div
-          = f.text_field :bio, class: 'text-field'
+          = f.text_area :bio, class: 'text-area'
       .btn-container
         = f.submit '保存', class: 'btn-secondary'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -68,10 +68,10 @@
               %li.display-group-content= favorite_band.name
     .profile-section
       .display-title SNSリンク
-      .display-text= @profile.sns_links
+      .display-text= simple_format(@profile.sns_links)
     .profile-section
       .display-title 自己紹介
-      .display-text= @profile.bio
+      .display-text= simple_format(@profile.bio)
     -# プロフィール編集画面へのリンク
     .display-edit-btn
       = link_to "編集", edit_profile_path, class: "btn-secondary"

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -43,6 +43,10 @@ ja:
         cover: "コピー"
         session: "セッション"
         arranged_cover: "アレンジカバー"
+      status:
+        recruiting: "募集中"
+        full: "定員到達"
+        closed: "募集締切"
     recruitment_part:
       part:
         vocal: "ボーカル"

--- a/db/migrate/20260604234756_change_practice_frequency_unit_to_integer.rb
+++ b/db/migrate/20260604234756_change_practice_frequency_unit_to_integer.rb
@@ -1,0 +1,11 @@
+class ChangePracticeFrequencyUnitToInteger < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :band_recruitments, :practice_frequency_unit
+    add_column :band_recruitments, :practice_frequency_unit, :integer
+  end
+
+  def down
+    remove_column :band_recruitments, :practice_frequency_unit
+    add_column :band_recruitments, :practice_frequency_unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_153431) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -61,7 +61,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_153431) do
     t.date "deadline", null: false
     t.integer "music_type"
     t.integer "practice_frequency_count"
-    t.string "practice_frequency_unit"
+    t.integer "practice_frequency_unit"
     t.integer "practice_style"
     t.integer "status", default: 0
     t.string "team_name"


### PR DESCRIPTION
【実装内容】
・enums.ja.ymlに以下の各項目のenumの日本語訳を定義
　・活動志向（activity_style）
　・練習単位（practice_frequency_unit）
　・練習スタイル（practice_style）
　・楽曲タイプ（music_type）
　・募集ステータス（status）
・募集一覧・詳細画面でI18nを使用して日本語・略語表示に変更

【追加対応】
・募集一覧画面の最後の募集と募集追加ボタンが重複しないようにUI調整
・募集一覧画面の募集表示を更新順（降順）に修正
・プロフィール画面のSNSリンクと自己紹介が改行されるように修正

【確認内容】
・募集一覧・詳細画面で正しく日本語・略語表示されていることを確認
・募集一覧画面の最後の募集と募集追加ボタンが重複していないことを確認
・募集一覧が更新順（降順）で表示されることを確認
・プロフィール画面にてSNSリンクと自己紹介の改行が反映されていることを確認

Closes #88