### PR TITLE
中間テーブルにDB制約を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,15 @@ body {
   width: 100%;
 }
 
+.error-message-container {
+  padding: 0 0 0 20px;
+  margin: 0 0 15px 0;
+}
+
+.error-message {
+  list-style: none;
+}
+
 .flash {
   position: absolute;
   top: 15px;

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -34,6 +34,7 @@ class Profile < ApplicationRecord
   # バリデーション設定
   validates :nickname, presence: true, length: { maximum: 20 }
   validates :gender, presence: true
+  validates :birth_date, presence: true
   validate :valid_age_range
   validates :part, presence: true
   validates :bio, length: { maximum: 300 }
@@ -49,21 +50,18 @@ class Profile < ApplicationRecord
 
   # 年齢を制限
   def valid_age_range
-    if birth_date.blank?
-      errors.add(:birth_date, "を入力してください")
-      return
-    end
+    return if birth_date.blank?
 
     age = calculate_age
 
     # ユーザーは13歳以上100歳未満であること
     if age < 13
-      errors.add(:birth_date, "は13歳以上である必要があります")
+      errors.add(:base, "13歳以上の方のみ登録できます")
     end
 
     # 13歳未満は登録不可
     if age > 100
-      errors.add(:birth_date, "の年齢が不正です")
+      errors.add(:base, "正しい生年月日を入力してください")
     end
   end
 

--- a/app/models/profile_activity_area.rb
+++ b/app/models/profile_activity_area.rb
@@ -3,5 +3,5 @@ class ProfileActivityArea < ApplicationRecord
   belongs_to :activity_area
 
   # バリデーション設定（同じ活動地域の重複登録を防止）
-  validates :profile_id, uniqueness: { scope: :activity_area_id }
+  validates :activity_area_id, uniqueness: { scope: :profile_id }
 end

--- a/app/models/profile_activity_genre.rb
+++ b/app/models/profile_activity_genre.rb
@@ -3,5 +3,5 @@ class ProfileActivityGenre < ApplicationRecord
   belongs_to :activity_genre
 
   # バリデーション設定（同じ活動ジャンルの重複登録を防止）
-  validates :profile_id, uniqueness: { scope: :activity_genre_id }
+  validates :activity_genre_id, uniqueness: { scope: :profile_id }
 end

--- a/app/models/profile_favorite_band.rb
+++ b/app/models/profile_favorite_band.rb
@@ -3,5 +3,5 @@ class ProfileFavoriteBand < ApplicationRecord
   belongs_to :favorite_band
 
   # バリデーション設定（同じ好きなバンドタグの重複登録を防止）
-  validates :profile_id, uniqueness: { scope: :favorite_band_id }
+  validates :favorite_band_id, uniqueness: { scope: :profile_id }
 end

--- a/app/models/profile_personality.rb
+++ b/app/models/profile_personality.rb
@@ -3,5 +3,5 @@ class ProfilePersonality < ApplicationRecord
   belongs_to :personality
 
   # バリデーション設定（同じ性格タグの重複登録を防止）
-  validates :profile_id, uniqueness: { scope: :personality_id }
+  validates :personality_id, uniqueness: { scope: :profile_id }
 end

--- a/app/models/recruitment_activity_area.rb
+++ b/app/models/recruitment_activity_area.rb
@@ -3,5 +3,5 @@ class RecruitmentActivityArea < ApplicationRecord
   belongs_to :activity_area
 
   # バリデーション設定（同じ活動地域の重複登録を防止）
-  validates :band_recruitment_id, uniqueness: { scope: :activity_area_id }
+  validates :activity_area_id, uniqueness: { scope: :band_recruitment_id }
 end

--- a/app/models/recruitment_activity_genre.rb
+++ b/app/models/recruitment_activity_genre.rb
@@ -3,5 +3,5 @@ class RecruitmentActivityGenre < ApplicationRecord
   belongs_to :activity_genre
 
   # バリデーション設定（同じ活動ジャンルの重複登録を防止）
-  validates :band_recruitment_id, uniqueness: { scope: :activity_genre_id }
+  validates :activity_genre_id, uniqueness: { scope: :band_recruitment_id }
 end

--- a/app/views/band_recruitments/edit.html.haml
+++ b/app/views/band_recruitments/edit.html.haml
@@ -1,9 +1,9 @@
 .container
   -# エラーがある場合、メッセージを表示
   -if @band_recruitment.errors.any?
-    %ul
+    %ul.error-message-container
       - @band_recruitment.errors.full_messages.each do |message|
-        %li= message
+        %li.error-message= "※#{message}"
   .form-title 募集内容
   .form-container
     = form_with(model: @band_recruitment, url: band_recruitment_path(@band_recruitment), method: 'patch', local: true) do |f|

--- a/app/views/band_recruitments/new.html.haml
+++ b/app/views/band_recruitments/new.html.haml
@@ -1,9 +1,9 @@
 .container
   -# エラーがある場合、メッセージを表示
   -if @band_recruitment.errors.any?
-    %ul
+    %ul.error-message-container
       - @band_recruitment.errors.full_messages.each do |message|
-        %li= message
+        %li.error-message= "※#{message}"
   .form-title 募集内容
   .form-container
     = form_with(model: @band_recruitment, url: band_recruitments_path, method: 'post', local: true) do |f|

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -1,9 +1,9 @@
 .container
   -# エラーがある場合、メッセージを表示
   -if @profile.errors.any?
-    %ul
+    %ul.error-message-container
       - @profile.errors.full_messages.each do |message|
-        %li= message
+        %li.error-message= "※#{message}"
   .form-title プロフィールの編集
   .form-container
     = form_with(model: @profile, url: profile_path, method: 'patch', local: true) do |f|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,196 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+    attributes:
+      profile:
+        nickname: "ニックネーム"
+        gender: "性別"
+        birth_date: "生年月日"
+        part: "担当パート"
+        bio: "自己紹介"
+      band_recruitment:
+        title: "タイトル"
+        deadline: "期限"
+        comment: "コメント"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      password_too_long: が長すぎます
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        negative_format: "-%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+          zb: ZB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/db/migrate/20260607030834_add_unique_index_to_profile_activity_genres.rb
+++ b/db/migrate/20260607030834_add_unique_index_to_profile_activity_genres.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToProfileActivityGenres < ActiveRecord::Migration[8.1]
+  def change
+    add_index :profile_activity_genres,
+    [ :profile_id, :activity_genre_id ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607032346_add_unique_index_to_profile_activity_areas.rb
+++ b/db/migrate/20260607032346_add_unique_index_to_profile_activity_areas.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToProfileActivityAreas < ActiveRecord::Migration[8.1]
+  def change
+    add_index :profile_activity_areas,
+    [ :profile_id, :activity_area_id ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607032806_add_unique_index_to_profile_personalities.rb
+++ b/db/migrate/20260607032806_add_unique_index_to_profile_personalities.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToProfilePersonalities < ActiveRecord::Migration[8.1]
+  def change
+    add_index :profile_personalities,
+    [ :profile_id, :personality_id ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607033157_add_unique_index_to_profile_favorite_bands.rb
+++ b/db/migrate/20260607033157_add_unique_index_to_profile_favorite_bands.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToProfileFavoriteBands < ActiveRecord::Migration[8.1]
+  def change
+    add_index :profile_favorite_bands,
+    [ :profile_id, :favorite_band_id ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607042119_add_unique_index_to_recruitment_parts.rb
+++ b/db/migrate/20260607042119_add_unique_index_to_recruitment_parts.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToRecruitmentParts < ActiveRecord::Migration[8.1]
+  def change
+    add_index :recruitment_parts,
+    [ :band_recruitment_id, :part ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607042642_add_unique_index_to_recruitment_activity_genres.rb
+++ b/db/migrate/20260607042642_add_unique_index_to_recruitment_activity_genres.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToRecruitmentActivityGenres < ActiveRecord::Migration[8.1]
+  def change
+    add_index :recruitment_activity_genres,
+    [ :band_recruitment_id, :activity_genre_id ],
+    unique: true
+  end
+end

--- a/db/migrate/20260607043432_add_unique_index_to_recruitment_activity_areas.rb
+++ b/db/migrate/20260607043432_add_unique_index_to_recruitment_activity_areas.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToRecruitmentActivityAreas < ActiveRecord::Migration[8.1]
+  def change
+    add_index :recruitment_activity_areas,
+    [ :band_recruitment_id, :activity_area_id ],
+    unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_07_043432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.bigint "profile_id", null: false
     t.datetime "updated_at", null: false
     t.index ["activity_area_id"], name: "index_profile_activity_areas_on_activity_area_id"
+    t.index ["profile_id", "activity_area_id"], name: "idx_on_profile_id_activity_area_id_618dbedb90", unique: true
     t.index ["profile_id"], name: "index_profile_activity_areas_on_profile_id"
   end
 
@@ -99,6 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.bigint "profile_id", null: false
     t.datetime "updated_at", null: false
     t.index ["activity_genre_id"], name: "index_profile_activity_genres_on_activity_genre_id"
+    t.index ["profile_id", "activity_genre_id"], name: "idx_on_profile_id_activity_genre_id_8ae5e106cf", unique: true
     t.index ["profile_id"], name: "index_profile_activity_genres_on_profile_id"
   end
 
@@ -108,6 +110,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.bigint "profile_id", null: false
     t.datetime "updated_at", null: false
     t.index ["favorite_band_id"], name: "index_profile_favorite_bands_on_favorite_band_id"
+    t.index ["profile_id", "favorite_band_id"], name: "idx_on_profile_id_favorite_band_id_902e3d8115", unique: true
     t.index ["profile_id"], name: "index_profile_favorite_bands_on_profile_id"
   end
 
@@ -117,6 +120,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.bigint "profile_id", null: false
     t.datetime "updated_at", null: false
     t.index ["personality_id"], name: "index_profile_personalities_on_personality_id"
+    t.index ["profile_id", "personality_id"], name: "index_profile_personalities_on_profile_id_and_personality_id", unique: true
     t.index ["profile_id"], name: "index_profile_personalities_on_profile_id"
   end
 
@@ -145,6 +149,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["activity_area_id"], name: "index_recruitment_activity_areas_on_activity_area_id"
+    t.index ["band_recruitment_id", "activity_area_id"], name: "idx_on_band_recruitment_id_activity_area_id_4bdb50643d", unique: true
     t.index ["band_recruitment_id"], name: "index_recruitment_activity_areas_on_band_recruitment_id"
   end
 
@@ -154,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["activity_genre_id"], name: "index_recruitment_activity_genres_on_activity_genre_id"
+    t.index ["band_recruitment_id", "activity_genre_id"], name: "idx_on_band_recruitment_id_activity_genre_id_c7aabd4499", unique: true
     t.index ["band_recruitment_id"], name: "index_recruitment_activity_genres_on_band_recruitment_id"
   end
 
@@ -163,6 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_234756) do
     t.integer "max_count", null: false
     t.integer "part", null: false
     t.datetime "updated_at", null: false
+    t.index ["band_recruitment_id", "part"], name: "index_recruitment_parts_on_band_recruitment_id_and_part", unique: true
     t.index ["band_recruitment_id"], name: "index_recruitment_parts_on_band_recruitment_id"
   end
 


### PR DESCRIPTION
【対象テーブル】
・profile_activity_genres
・profile_activity_areas
・profile_personalities
・profile_favorite_bands
・recruitment_parts
・recruitment_activity_genres
・recruitment_activity_areas

【実装内容】
・各中間テーブルに複合ユニーク制約を追加
・新規migrationファイルを作成して対応

【追加対応】
・エラーメッセージの日本語化
・バリデーションメッセージの表示修正

【確認内容】
・Rails consoleで同一データの重複登録がエラーとなることを確認
・エラーメッセージが日本語化されることを確認
・バリデーションメッセージが修正されていることを確認

Closes #66