### PR TITLE
参加希望（recruitment_applications）テーブル作成

### DIFF
--- a/app/models/band_recruitment.rb
+++ b/app/models/band_recruitment.rb
@@ -15,6 +15,10 @@ class BandRecruitment < ApplicationRecord
   accepts_nested_attributes_for :recruitment_parts,
     # 必要人数がblankの募集パートは保存しない
     reject_if: ->(attr) { attr["max_count"].blank? }, allow_destroy: true
+  # 募集と参加希望の多対多関係を中間テーブルで管理
+  has_many :recruitment_applications, dependent: :destroy
+  # 募集に紐づくユーザーを取得（中間テーブル経由）
+  has_many :users, through: :recruitment_applications
 
   # 活動志向のパターンを定義
   enum :activity_style, { hobby: 0, amateur: 1, professional: 2 }

--- a/app/models/recruitment_application.rb
+++ b/app/models/recruitment_application.rb
@@ -1,0 +1,12 @@
+class RecruitmentApplication < ApplicationRecord
+  belongs_to :user
+  belongs_to :band_recruitment
+
+  # 応募パートのパターンを定義
+  enum :application_part, { vocal: 0, guitar: 1, bass: 2, drums: 3, keyboard: 4 }
+  # 応募ステータスのパターンを定義
+  enum :status, { pending: 0, approved: 1, rejected: 2 }
+
+  # バリデーション設定（同じ募集への参加希望の重複登録を防止）
+  validates :user_id, uniqueness: { scope: :band_recruitment_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,10 @@ class User < ApplicationRecord
   has_one :profile, dependent: :destroy
   # UserモデルとBandRecruitmentモデルを紐付け
   has_many :band_recruitments, dependent: :destroy
+  # ユーザーと参加希望の多対多関係を中間テーブルで管理
+  has_many :recruitment_applications, dependent: :destroy
+  # ユーザーに紐づく募集を取得（中間テーブル経由）
+  has_many :band_recruitments, through: :recruitment_applications
 
   def prepare_profile
     # profileがあればそれを返し、なければ新しく作る

--- a/db/migrate/20260607100309_create_recruitment_applications.rb
+++ b/db/migrate/20260607100309_create_recruitment_applications.rb
@@ -1,0 +1,21 @@
+class CreateRecruitmentApplications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :recruitment_applications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :band_recruitment, null: false, foreign_key: true
+      # 参加希望コメント
+      t.text :application_comment
+      # 承認コメント
+      t.text :approval_comment
+      # 応募パート
+      t.integer :application_part, null: false
+      # 承認ステータス
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :recruitment_applications,
+    [ :user_id, :band_recruitment_id ],
+    unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_043432) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_07_100309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -163,6 +163,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_043432) do
     t.index ["band_recruitment_id"], name: "index_recruitment_activity_genres_on_band_recruitment_id"
   end
 
+  create_table "recruitment_applications", force: :cascade do |t|
+    t.text "application_comment"
+    t.integer "application_part", null: false
+    t.text "approval_comment"
+    t.bigint "band_recruitment_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["band_recruitment_id"], name: "index_recruitment_applications_on_band_recruitment_id"
+    t.index ["user_id", "band_recruitment_id"], name: "idx_on_user_id_band_recruitment_id_077dab728f", unique: true
+    t.index ["user_id"], name: "index_recruitment_applications_on_user_id"
+  end
+
   create_table "recruitment_parts", force: :cascade do |t|
     t.bigint "band_recruitment_id", null: false
     t.datetime "created_at", null: false
@@ -201,5 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_043432) do
   add_foreign_key "recruitment_activity_areas", "band_recruitments"
   add_foreign_key "recruitment_activity_genres", "activity_genres"
   add_foreign_key "recruitment_activity_genres", "band_recruitments"
+  add_foreign_key "recruitment_applications", "band_recruitments"
+  add_foreign_key "recruitment_applications", "users"
   add_foreign_key "recruitment_parts", "band_recruitments"
 end

--- a/test/fixtures/recruitment_applications.yml
+++ b/test/fixtures/recruitment_applications.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  band_recruitment: one
+
+two:
+  user: two
+  band_recruitment: two

--- a/test/models/recruitment_application_test.rb
+++ b/test/models/recruitment_application_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecruitmentApplicationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【実装内容】
・RecruitmentApplicationモデルを作成
・recruitment_applicationsテーブルを作成
・必要カラムを追加
・enumを定義
・usersとband_recruitmentsの多:多関連付けを設定
・同一ユーザーが同一募集に重複応募できない制約を追加（DB・バリデーション）

【確認内容】
・Rails consoleで紐付けを確認

Closes #91