### PR TITLE
相性表示機能の実装

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -19,9 +19,10 @@
 }
 
 .recruitment-card-top {
+  height: 37px;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: start;
 }
 
 .recruitment-card-top-left {
@@ -29,6 +30,34 @@
   justify-content: start;
   align-items: center;
   gap: 8px;
+}
+
+.recruitment-card-top-right {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  justify-content: center;
+}
+
+.card-recruitment-compatibility {
+  font-size: 13px;
+
+  &.application {
+    font-size: 10px;
+  }
+
+  span {
+    color: $main-color;
+  }
+}
+
+.card-profile-compatibility {
+  font-size: 11px;
+
+  span {
+    color: $main-color;
+  }
 }
 
 .card-status {
@@ -199,6 +228,6 @@
 
 .card-icon-profile {
   position: absolute;
-  top: 30px;
-  right: 25px;
+  top: 47px;
+  right: 26px;
 }

--- a/app/assets/stylesheets/display.scss
+++ b/app/assets/stylesheets/display.scss
@@ -125,9 +125,11 @@
 }
 
 .display-my-application-status {
-  padding: 3px 8px;
-  margin-top: 4px;
-  font-size: 13px;
+  padding: 2px 8px;
+  margin-top: 12px;
+  font-size: 12px;
+  text-align: center;
+  width: 70px;
 
   &.approved {
     background-color: $secondary-color;

--- a/app/views/band_recruitments/index.html.haml
+++ b/app/views/band_recruitments/index.html.haml
@@ -8,6 +8,12 @@
               = t("enums.band_recruitment.status.#{band_recruitment.status}")
             .card-deadline= "期限：#{band_recruitment.deadline}"
           .recruitment-card-top-right
+            - if band_recruitment.user == current_user
+              .card-recruitment-compatibility 自分の募集
+            - else
+              .card-recruitment-compatibility
+                募集相性:
+                %span= "#{band_recruitment.recruitment_compatibility_with(current_user.profile)}%"
         .recruitment-card-middle
           .card-team
             .card-team-title チーム名

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -11,6 +11,12 @@
           = t("enums.band_recruitment.status.#{@band_recruitment.status}")
         .card-deadline= "期限：#{@band_recruitment.deadline}"
       .recruitment-card-top-right
+        - if @band_recruitment.user == current_user
+          .card-recruitment-compatibility 自分の募集
+        - else
+          .card-recruitment-compatibility
+            募集相性:
+            %span= "#{@band_recruitment.recruitment_compatibility_with(current_user.profile)}%"
     .recruitment-card-middle
       .card-team
         .card-team-title チーム名
@@ -88,6 +94,9 @@
               - @band_recruitment.recruitment_applications.each do |recruitment_application|
                 .display-application
                   .card-icon-container.application
+                    .card-profile-compatibility
+                      相性:
+                      %span= "#{current_user.profile.profile_compatibility_with(recruitment_application.user.profile)}%"
                     = image_tag recruitment_application.user.profile.avatar_image, class: "card-icon application"
                     -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
                     = link_to profile_path(recruitment_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do

--- a/app/views/recruitment_applications/index.html.haml
+++ b/app/views/recruitment_applications/index.html.haml
@@ -17,6 +17,12 @@
                   .display-my-application-status.approved 承認
                 - else
                   .display-my-application-status.pending 承認待ち
+            - if band_recruitment.user == current_user
+              .card-recruitment-compatibility 自分の募集
+            - else
+              .card-recruitment-compatibility.application
+                募集相性:
+                %span= "#{band_recruitment.recruitment_compatibility_with(current_user.profile)}%"
         .recruitment-card-middle
           .card-team
             .card-team-title チーム名


### PR DESCRIPTION
【実装内容】
・募集一覧に募集相性を表示
・募集詳細画面に募集相性を表示
・応募者一覧に人物相性を表示
・自分が作成した募集には相性を表示せず、「自分の募集」と表示する
・相性は％で表示

【確認内容】
・募集一覧で募集相性が表示されること
・募集詳細画面で募集相性が表示されること
・応募者一覧で人物相性が表示されること
・自分が作成した募集には相性ではなく「自分の募集」と表示されること

Closes #105