### PR TITLE
募集者のプロフィール閲覧機能の追加

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -183,6 +183,7 @@
     margin: 10px 0 0 auto;
     width: fit-content;
     justify-content: center;
+    gap: 15px;
   }
 
   &.application {
@@ -195,27 +196,30 @@
   }
 }
 
+.card-icon-img {
+  position: relative;
+}
+
 .card-icon {
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  width: 45px;
+  height: 45px;
   display: block;
   margin: 0;
-
-  &.application {
-    width: 45px;
-    height: 45px;
-  }
 }
 
 .card-icon-info {
+  &.detail {
+    margin-left: 15px;
+  }
+
   &.application {
     text-align: center;
   }
 }
 
 .card-icon-info-top {
-  font-size: 11px;
+  font-size: 12px;
 
   &.application {
     font-size: 13px;
@@ -223,11 +227,5 @@
 }
 
 .card-icon-info-bottom {
-  font-size: 9px;
-}
-
-.card-icon-profile {
-  position: absolute;
-  top: 47px;
-  right: 26px;
+  font-size: 10px;
 }

--- a/app/assets/stylesheets/icon.scss
+++ b/app/assets/stylesheets/icon.scss
@@ -1,8 +1,11 @@
 .magnifying-glass-icon {
+  position: absolute;
   width: 15px;
   height: 15px;
   display: block;
   margin: 0;
+  top: 30px;
+  right: -11px;
 }
 
 .check-icon {

--- a/app/views/band_recruitments/_application_messages.html.haml
+++ b/app/views/band_recruitments/_application_messages.html.haml
@@ -9,11 +9,12 @@
             .card-profile-compatibility
               相性:
               %span= "#{current_user.profile.profile_compatibility_with(recruitment_application.user.profile)}%"
-            = image_tag recruitment_application.user.profile.avatar_image, class: "card-icon application"
-            -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-            = link_to profile_path(recruitment_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
-              = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
-            = turbo_frame_tag "profile_modal"
+            .card-icon-img
+              = image_tag recruitment_application.user.profile.avatar_image, class: "card-icon"
+              -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
+              = link_to profile_path(recruitment_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+                = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
+              = turbo_frame_tag "profile_modal"
             .card-icon-info.application
               .card-icon-info-top.application= "#{recruitment_application.user.profile.nickname} (#{t("ui.parts.short.#{recruitment_application.user.profile.part}")})"
               .card-icon-info-bottom.application= "#{recruitment_application.user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{recruitment_application.user.profile.gender}")}"

--- a/app/views/band_recruitments/_approved_members.html.haml
+++ b/app/views/band_recruitments/_approved_members.html.haml
@@ -8,11 +8,12 @@
             .card-profile-compatibility
               相性:
               %span= "#{current_user.profile.profile_compatibility_with(approved_application.user.profile)}%"
-            = image_tag approved_application.user.profile.avatar_image, class: "card-icon application"
-            -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-            = link_to profile_path(approved_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
-              = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
-            = turbo_frame_tag "profile_modal"
+            .card-icon-img
+              = image_tag approved_application.user.profile.avatar_image, class: "card-icon"
+              -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
+              = link_to profile_path(approved_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+                = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
+              = turbo_frame_tag "profile_modal"
             .card-icon-info.application
               .card-icon-info-top.application= "#{approved_application.user.profile.nickname} (#{t("ui.parts.short.#{approved_application.user.profile.part}")})"
               .card-icon-info-bottom.application= "#{approved_application.user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{approved_application.user.profile.gender}")}"

--- a/app/views/band_recruitments/_my_application_messages.html.haml
+++ b/app/views/band_recruitments/_my_application_messages.html.haml
@@ -5,7 +5,12 @@
     .display-title 応募メッセージ
     .display-application
       .card-icon-container.application
-        = image_tag current_user.profile.avatar_image, class: 'card-icon application'
+        .card-icon-img
+          = image_tag current_user.profile.avatar_image, class: 'card-icon'
+          -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
+          = link_to profile_path(current_user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+            = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
+          = turbo_frame_tag "profile_modal"
         .card-icon-info.application
           .card-icon-info-top.application= "#{current_user.profile.nickname} (#{t("ui.parts.short.#{current_user.profile.part}")})"
           .card-icon-info-bottom.application= "#{current_user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{current_user.profile.gender}")}"

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -58,7 +58,12 @@
           .card-team-name 未設定
       .card-title= @band_recruitment.title
       .card-icon-container.detail
-        = image_tag @band_recruitment.user.profile.avatar_image, class: 'card-icon'
+        .card-icon-img
+          = image_tag @band_recruitment.user.profile.avatar_image, class: 'card-icon'
+          -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
+          = link_to profile_path(@band_recruitment.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+            = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
+          = turbo_frame_tag "profile_modal"
         .card-icon-info
           .card-icon-info-top= "#{@band_recruitment.user.profile.nickname} (#{t("ui.parts.short.#{@band_recruitment.user.profile.part}")})"
           .card-icon-info-bottom= "#{@band_recruitment.user.profile.calculate_age}歳 / #{t("enums.profile.gender.#{@band_recruitment.user.profile.gender}")}"


### PR DESCRIPTION
【実装内容】
・募集詳細画面に募集者のプロフィール表示アイコンを追加
・アイコンクリックで、募集者のプロフィールがモーダル表示されるように実装

【確認内容】
・募集詳細画面でアイコンをクリックすると、募集者のプロフィールがモーダル表示されることを確認
・モーダルが閉じられることを確認

Closes #113