### PR TITLE
応募承認後のSNSリンク表示機能

### DIFF
--- a/app/controllers/band_recruitments_controller.rb
+++ b/app/controllers/band_recruitments_controller.rb
@@ -59,7 +59,7 @@ class BandRecruitmentsController < ApplicationController
 
     # DBに値が保存されれば、作成された募集ページに飛ぶ
     if @band_recruitment.save
-      redirect_to band_recruitment_path(@band_recruitment), notice: "作成できました"
+      redirect_to band_recruitment_path(@band_recruitment, source: "my-band-recruitment"), notice: "作成できました"
     else
       rebuild_parts
       flash.now[:error] = "作成できませんでした"
@@ -71,7 +71,7 @@ class BandRecruitmentsController < ApplicationController
   def edit
     # 一人でも承認したら、その募集の編集・削除はできない
     if @band_recruitment.recruitment_applications.approved.exists? || @band_recruitment.status == "closed"
-      redirect_to band_recruitment_path(@band_recruitment), alert: "編集できません"
+      redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "編集できません"
     end
       rebuild_parts
   end
@@ -86,7 +86,7 @@ class BandRecruitmentsController < ApplicationController
 
     # 更新できたら、更新した募集詳細画面に飛ぶ
     if @band_recruitment.update(band_recruitment_params)
-      redirect_to band_recruitment_path(@band_recruitment), notice: "更新できました"
+      redirect_to band_recruitment_path(@band_recruitment, source: "my-band-recruitment"), notice: "更新できました"
     else
       rebuild_parts
       flash.now[:error] = "更新できませんでした"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,6 +10,12 @@ class ProfilesController < ApplicationController
     unless turbo_frame_request? || @profile.user == current_user
       redirect_to root_path, alert: "権限がありません"
     end
+
+    # どの画面から遷移したか
+    @source = params[:source]
+    if turbo_frame_request?
+      @band_recruitment = BandRecruitment.find(params[:band_recruitment_id])
+    end
   end
 
   def new

--- a/app/controllers/recruitment_applications_controller.rb
+++ b/app/controllers/recruitment_applications_controller.rb
@@ -43,13 +43,13 @@ class RecruitmentApplicationsController < ApplicationController
 
     # 募集パートがなければ、エラーメッセージを表示
     unless @band_recruitment.recruitment_parts.exists?(part: @application.application_part)
-      redirect_to band_recruitment_path(@band_recruitment), alert: "このパートは募集されていません"
+      redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "このパートは募集されていません"
       return
     end
 
     # 承認するパートが定員に達していたら、エラーメッセージを表示
     if @band_recruitment.part_full?(@application.application_part)
-      redirect_to band_recruitment_path(@band_recruitment), alert: "このパートは定員に達しています"
+      redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "このパートは定員に達しています"
       return
     end
 
@@ -69,7 +69,7 @@ class RecruitmentApplicationsController < ApplicationController
     if params[:status] == "approved"
       # 承認するパートが定員に達していたら、エラーメッセージを表示
       if @band_recruitment.part_full?(@application.application_part)
-        redirect_to band_recruitment_path(@band_recruitment), alert: "このパートは定員に達しています"
+        redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "このパートは定員に達しています"
         return
       end
       if @application.update(status: :approved)
@@ -81,18 +81,18 @@ class RecruitmentApplicationsController < ApplicationController
         if @band_recruitment.all_parts_full?
           @band_recruitment.update(status: :full)
         end
-        redirect_to band_recruitment_path(@band_recruitment), notice: "承認しました"
+        redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), notice: "承認しました"
       else
-        redirect_to band_recruitment_path(@band_recruitment), alert: "承認できませんでした"
+        redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "承認できませんでした"
       end
     elsif params[:status] == "rejected"
       if @application.update(status: :rejected)
-        redirect_to band_recruitment_path(@band_recruitment), notice: "見送りました"
+        redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), notice: "見送りました"
       else
-        redirect_to band_recruitment_path(@band_recruitment), alert: "見送りできませんでした"
+        redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "見送りできませんでした"
       end
     else
-      redirect_to band_recruitment_path(@band_recruitment), alert: "操作できませんでした"
+      redirect_to band_recruitment_path(@band_recruitment, source: params[:source]), alert: "操作できませんでした"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,14 @@ class User < ApplicationRecord
   # ユーザーに紐づく募集を取得（中間テーブル経由）
   has_many :applied_band_recruitments, through: :recruitment_applications,
            source: :band_recruitment
+
+  def connected_with?(other_user, band_recruitment)
+    # 自分の募集に対してその応募者が承認されているか
+    if band_recruitment.user_id == id
+      other_user.recruitment_applications.approved.where(band_recruitment_id: band_recruitment.id).exists?
+    # 他人の募集に対して自分の応募が承認されているか
+    elsif band_recruitment.user_id == other_user.id
+      recruitment_applications.approved.where(band_recruitment_id: band_recruitment.id).exists?
+    end
+  end
 end

--- a/app/views/band_recruitments/_application_messages.html.haml
+++ b/app/views/band_recruitments/_application_messages.html.haml
@@ -12,7 +12,7 @@
             .card-icon-img
               = image_tag recruitment_application.user.profile.avatar_image, class: "card-icon"
               -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-              = link_to profile_path(recruitment_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+              = link_to profile_path(recruitment_application.user.profile, band_recruitment_id: @band_recruitment, source: @source), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
                 = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
               = turbo_frame_tag "profile_modal"
             .card-icon-info.application
@@ -30,8 +30,8 @@
                 -# 「参加希望」-「相手から」タブなら承認する/見送る操作が可能
               - elsif @source == "received"
                 .display-btn-container
-                  = button_to "見送る", band_recruitment_recruitment_application_path(@band_recruitment, recruitment_application), method: "patch", data: { turbo_confirm: "この応募を見送りますか？"}, params: { status: :rejected }, class: "btn-third rejected"
+                  = button_to "見送る", band_recruitment_recruitment_application_path(@band_recruitment, recruitment_application, source: @source), method: "patch", data: { turbo_confirm: "この応募を見送りますか？"}, params: { status: :rejected }, class: "btn-third rejected"
                 .display-btn-container
-                  = button_to "承認する", band_recruitment_recruitment_application_path(@band_recruitment, recruitment_application), method: "patch", data: { turbo_confirm: "この応募を承認しますか？"}, params: { status: :approved }, class: "btn-third approved"
+                  = button_to "承認する", band_recruitment_recruitment_application_path(@band_recruitment, recruitment_application, source: @source), method: "patch", data: { turbo_confirm: "この応募を承認しますか？"}, params: { status: :approved }, class: "btn-third approved"
           - if recruitment_application.application_comment.present?
             .display-text.application= simple_format(recruitment_application.application_comment)

--- a/app/views/band_recruitments/_approved_members.html.haml
+++ b/app/views/band_recruitments/_approved_members.html.haml
@@ -11,7 +11,7 @@
             .card-icon-img
               = image_tag approved_application.user.profile.avatar_image, class: "card-icon"
               -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-              = link_to profile_path(approved_application.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+              = link_to profile_path(approved_application.user.profile, band_recruitment_id: @band_recruitment, source: @source), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
                 = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
               = turbo_frame_tag "profile_modal"
             .card-icon-info.application

--- a/app/views/band_recruitments/_my_application_messages.html.haml
+++ b/app/views/band_recruitments/_my_application_messages.html.haml
@@ -8,7 +8,7 @@
         .card-icon-img
           = image_tag current_user.profile.avatar_image, class: 'card-icon'
           -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-          = link_to profile_path(current_user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+          = link_to profile_path(current_user.profile, band_recruitment_id: @band_recruitment, source: @source), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
             = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
           = turbo_frame_tag "profile_modal"
         .card-icon-info.application

--- a/app/views/band_recruitments/show.html.haml
+++ b/app/views/band_recruitments/show.html.haml
@@ -61,7 +61,7 @@
         .card-icon-img
           = image_tag @band_recruitment.user.profile.avatar_image, class: 'card-icon'
           -# リンクをクリックしたら、画面遷移ではなく、profile_modal の中だけ更新
-          = link_to profile_path(@band_recruitment.user.profile), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
+          = link_to profile_path(@band_recruitment.user.profile, band_recruitment_id: @band_recruitment, source: @source), data: { turbo_frame: "profile_modal" }, class: "card-icon-profile" do
             = image_tag "magnifying-glass.svg", class: "magnifying-glass-icon"
           = turbo_frame_tag "profile_modal"
         .card-icon-info

--- a/app/views/profiles/_profile.html.haml
+++ b/app/views/profiles/_profile.html.haml
@@ -63,9 +63,13 @@
       %ul.display-group-wrapper
         - @profile.favorite_bands.each do |favorite_band|
           %li.display-group-content= favorite_band.name
-.profile-section
-  .display-title SNSリンク
-  .display-text= simple_format(@profile.sns_links)
+- if (@source == "received" || @source == "sent" || @source == "my-band-recruitment") && current_user.connected_with?(@profile.user, @band_recruitment) || @profile.user == current_user
+  .profile-section
+    .display-title SNSリンク
+    - if @profile.sns_links.blank?
+      .display-text 未登録
+    - else
+      .display-text= simple_format(@profile.sns_links)
 .profile-section
   .display-title 自己紹介
   .display-text= simple_format(@profile.bio)


### PR DESCRIPTION
【実装内容】
・応募承認後に募集者と応募者のプロフィールモーダル上で互いのSNSリンクを閲覧できるように実装
・応募承認前は募集者と応募者のSNSリンクが非表示になるように実装

【確認内容】
・応募承認後に募集者と応募者のプロフィールモーダル上で互いのSNSリンクが閲覧できることを確認
・応募承認前は募集者と応募者のSNSリンクが非表示であることを確認

【追加対応】
・redirect後の画面遷移を修正（source保持を追加）

Closes #112