### PR TITLE
ログイン画面の日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "hamlit"
 gem "sassc-rails"
 # ユーザー認証機能を簡単に実装するためのgem
 gem "devise"
+# deviseの国際化用
+gem "devise-i18n"
 # ダミーデータ作成用ツール
 gem "faker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.16.0)
+      devise (>= 5.0.0)
+      rails-i18n
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -290,6 +293,9 @@ GEM
     rails-html-sanitizer (1.7.1)
       loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3.1)
       actionpack (= 8.1.3.1)
       activesupport (= 8.1.3.1)
@@ -448,6 +454,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-i18n
   faker
   hamlit
   image_processing (~> 1.2)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   # ログインしていないと使えないようにする
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [ :new, :create, :edit, :update ]
   before_action :set_profile, only: [ :show, :edit, :update ]
   # 自分以外のプロフィールは編集できないようにする
   before_action :authorize_profile!, only: [ :edit, :update ]

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,12 +1,12 @@
 .container
-  %h2.devise-h2 Resend confirmation instructions
+  %h2.devise-h2 確認メールを再送する
   %div.devise-container
     = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: 'text-input'
       .actions
-        = f.submit "Resend confirmation instructions", class: 'devise-btn'
+        = f.submit "送信", class: 'devise-btn'
   = render "devise/shared/links"

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,21 +1,21 @@
 .container
-  %h2.devise-h2 Change your password
+  %h2.devise-h2 パスワードを変更する
   %div.devise-container
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
       = render "devise/shared/error_messages", resource: resource
       = f.hidden_field :reset_password_token
       .field
-        = f.label :password, "New password", class: 'text'
+        = f.label :password, "新しいパスワード", class: 'text'
         %br/
         - if @minimum_password_length
           %em
-            (#{@minimum_password_length} characters minimum)
+            (#{@minimum_password_length}文字以上)
           %br/
         = f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'text-input'
       .field
-        = f.label :password_confirmation, "Confirm new password", class: 'text'
+        = f.label :password_confirmation, "新しいパスワード(確認用)", class: 'text'
         %br/
         = f.password_field :password_confirmation, autocomplete: "new-password", class: 'text-input'
       .actions
-        = f.submit "Change my password", class: 'devise-btn'
+        = f.submit "変更", class: 'devise-btn'
   = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,12 +1,12 @@
 .container
-  %h2.devise-h2 Forgot your password?
+  %h2.devise-h2 パスワードをお忘れですか？
   %div.devise-container
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", class: 'text-input'
       .actions
-        = f.submit "Send me reset password instructions", class: 'devise-btn'
+        = f.submit "送信", class: 'devise-btn'
   = render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -5,14 +5,14 @@
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", class: 'text-input'
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         %div
           Currently waiting confirmation for: #{resource.unconfirmed_email}
       .field
-        = f.label :password, class: 'text'
+        = f.label :password, "パスワード", class: 'text'
         %i (leave blank if you don't want to change it)
         %br/
         = f.password_field :password, autocomplete: "new-password", class: 'text-input'
@@ -20,19 +20,19 @@
           %br/
           %em
             = @minimum_password_length
-            characters minimum
+            文字以上
       .field
-        = f.label :password_confirmation, class: 'text'
+        = f.label :password_confirmation, "パスワード(確認用)", class: 'text'
         %br/
         = f.password_field :password_confirmation, autocomplete: "new-password", class: 'text-input'
       .field
-        = f.label :current_password, class: 'text'
+        = f.label :current_password, "現在のパスワード", class: 'text'
         %i (we need your current password to confirm your changes)
         %br/
         = f.password_field :current_password, autocomplete: "current-password", class: 'text-input'
       .actions
-        = f.submit "Update", class: 'devise-btn'
+        = f.submit "更新", class: 'devise-btn'
     %h3 Cancel my account
     %div
-      Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete}
-    = link_to "Back", :back
+      Unhappy? #{button_to "削除", registration_path(resource_name), data: { confirm: "削除してもよろしいですか？", turbo_confirm: "削除してもよろしいですか？" }, method: :delete}
+    = link_to "戻る", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,23 +1,23 @@
 .container
-  %h2.devise-h2 Sign up
+  %h2.devise-h2 新規登録
   %div.devise-container
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", class: 'text-input'
       .field
-        = f.label :password, class: 'text'
+        = f.label :password, "パスワード", class: 'text'
         - if @minimum_password_length
           %em
-            (#{@minimum_password_length} characters minimum)
+            (#{@minimum_password_length}文字以上)
         %br/
         = f.password_field :password, autocomplete: "new-password", class: 'text-input'
       .field
-        = f.label :password_confirmation, class: 'text'
+        = f.label :password_confirmation, "パスワード(確認用)", class: 'text'
         %br/
         = f.password_field :password_confirmation, autocomplete: "new-password", class: 'text-input'
       .actions
-        = f.submit "Sign up", class: 'devise-btn'
+        = f.submit "ログイン", class: 'devise-btn'
   = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,19 +1,19 @@
 .container
-  %h2.devise-h2 Log in
+  %h2.devise-h2 ログイン
   %div.devise-container
     = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", class: 'text-input'
       .field
-        = f.label :password, class: 'text'
+        = f.label :password, "パスワード", class: 'text'
         %br/
         = f.password_field :password, autocomplete: "current-password", class: 'text-input'
       - if devise_mapping.rememberable?
         .field
           = f.check_box :remember_me
-          = f.label :remember_me, class: 'text-mini'
+          = f.label :remember_me, "ログイン状態を保持する", class: 'text-mini'
       .actions
-        = f.submit "Log in", class: 'devise-btn login'
+        = f.submit "ログイン", class: 'devise-btn login'
   = render "devise/shared/links"

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,19 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name), class: 'text-mini'
+  = link_to "ログイン", new_session_path(resource_name), class: 'text-mini'
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name), class: 'text-mini'
+  = link_to "新規登録", new_registration_path(resource_name), class: 'text-mini'
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name), class: 'text-mini'
+  = link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: 'text-mini'
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: 'text-mini'
+  = link_to "確認メールが届いていませんか？", new_confirmation_path(resource_name), class: 'text-mini'
   %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'text-mini'
+  = link_to "アカウントロック解除のメールが届いていませんか？", new_unlock_path(resource_name), class: 'text-mini'
   %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }
+    = button_to "#{OmniAuth::Utils.camelize(provider)}でログイン", omniauth_authorize_path(resource_name, provider), data: { turbo: false }
     %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,12 +1,12 @@
 .container
-  %h2.devise-h2 Resend unlock instructions
+  %h2.devise-h2 ロック解除用メールを再送する
   %div.devise-container
     = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
-        = f.label :email, class: 'text'
+        = f.label :email, "メールアドレス", class: 'text'
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email", class: 'text-input'
       .actions
-        = f.submit "Resend unlock instructions", class: 'devise-btn'
+        = f.submit "送信", class: 'devise-btn'
     = render "devise/shared/links"


### PR DESCRIPTION
【実装内容】
・ログイン画面を日本語化

【追加対応】
・未ログインユーザーも募集詳細画面から募集者のプロフィールを閲覧できるように実装

【確認内容】
・ログイン画面が日本語化されていることを確認
・未ログインユーザーも募集詳細画面から募集者のプロフィールを閲覧できることを確認

Closes #116